### PR TITLE
Sticky table columns and header

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -5625,12 +5625,13 @@ function Ktl($, appInfo) {
             const kw = '_sth';
             let numOfRecords = 10;
             let viewHeight = 800;
-            if (keywords[kw] && keywords[kw][0]?.params && keywords[kw][0]?.params[0].length) {
-                numOfRecords = keywords[kw][0].params[0][0] ? keywords[kw][0].params[0][0] : numOfRecords;
-                if (keywords[kw][0].params[0][1]) viewHeight = keywords[kw][0].params[0][1];
-                
+            if (keywords[kw]) {
+                if (keywords[kw].length) {
+                    numOfRecords = keywords[kw][0].params[0][0]
+                    viewHeight = keywords[kw][0].params[0][1]
+                }
+                ktl.views.stickTableHeaders(viewId, data, numOfRecords, viewHeight);
             }
-            ktl.views.stickTableHeaders(viewId, data, numOfRecords, viewHeight);
         }
         /* _stc = Make First col in table sticky
         * @param {string} viewId - The view.key
@@ -5638,10 +5639,12 @@ function Ktl($, appInfo) {
         function makeTableColumnSticky(viewId, keywords) {
             const kw = '_stc';
             let stickyBkgdColor = 'rgb(243 246 249)';
-            if (keywords[kw] && keywords[kw][0]?.params && keywords[kw][0]?.params[0].length) {
-                stickyBkgdColor = keywords[kw][0].params[0][0];
+            if (keywords[kw]) {
+                if (keywords[kw].length) {
+                    stickyBkgdColor = keywords[kw][0].params[0][0];
+                }
+                ktl.views.stickFirstColumn(viewId, stickyBkgdColor);
             }
-            ktl.views.stickFirstColumn(viewId, stickyBkgdColor);
         }
         /////////////////////////////////////////////////////////////////////////////////
         function colorizeFieldByValue(viewId, data) {
@@ -8945,14 +8948,13 @@ function Ktl($, appInfo) {
             stickTableHeaders: function (viewId, data, numOfRecords, viewHeight) {
                 if (data.length < numOfRecords) return;
                 $(`#${viewId} table, #${viewId} .kn-table-wrapper`)
-                    .addClass('ktlStickyHeader')
                     .css('height', viewHeight + 'px')
                     .find('th')
                     .css({'position': 'sticky', 'top': '-2px', 'z-index': '10'});
             },
             stickFirstColumn: function (viewId, stickyBkgdColor) {
-                $(`#${viewId} thead tr th:first-child`).addClass('ktlStickyColumn').css({'z-index': '50', 'position': 'sticky', 'left': '-1px'}); //make first col sticky
-                $(`#${viewId} tbody tr td:first-child`).addClass('ktlStickyColumn').css({'z-index': '20', 'position': 'sticky', 'left': '-1px','background-color': stickyBkgdColor}); //make first col sticky;
+                $(`#${viewId} thead tr th:first-child`).css({'z-index': '50', 'position': 'sticky', 'left': '-1px'}); //make first col sticky
+                $(`#${viewId} tbody tr td:first-child`).css({'z-index': '20', 'position': 'sticky', 'left': '-1px','background-color': stickyBkgdColor}); //make first col sticky;
             },
         }
     })(); //Views feature

--- a/KTL.js
+++ b/KTL.js
@@ -5627,8 +5627,8 @@ function Ktl($, appInfo) {
             let viewHeight = 800;
             if (keywords[kw]) {
                 if (keywords[kw].length) {
-                    numOfRecords = keywords[kw][0].params[0][0]
-                    viewHeight = keywords[kw][0].params[0][1]
+                    numOfRecords = keywords[kw][0].params[0][0];
+                    viewHeight = keywords[kw][0].params[0][1];
                 }
                 ktl.views.stickTableHeaders(viewId, data, numOfRecords, viewHeight);
             }

--- a/KTL.js
+++ b/KTL.js
@@ -5264,6 +5264,7 @@ function Ktl($, appInfo) {
                     keywords._ha && headerAlignment(view, keywords);
                     keywords._hsc && ktl.views.hideShowColumns(viewId, keywords);
                     keywords._dl && ktl.views.disableLinks(viewId, keywords);
+                    keywords._sth && makeTableHeaderSticky(viewId, keywords, data);
                 }
 
                 //This section is for keywords that are supported by views and fields.
@@ -5619,7 +5620,17 @@ function Ktl($, appInfo) {
                 }
             }
         }
-
+        function makeTableHeaderSticky(viewId, keywords, data) {
+            const kw = '_sth';
+            let numOfRecords = 10;
+            let viewHeight = 800;
+            if (keywords[kw] && keywords[kw][0]?.params && keywords[kw][0]?.params[0].length) {
+                numOfRecords = keywords[kw][0].params[0][0] ? keywords[kw][0].params[0][0] : numOfRecords;
+                if (keywords[kw][0].params[0][1]) viewHeight = keywords[kw][0].params[0][1];
+                
+            }
+            ktl.views.stickTableHeaders(viewId, data, numOfRecords, viewHeight);
+        }
         /////////////////////////////////////////////////////////////////////////////////
         function colorizeFieldByValue(viewId, data) {
             const CFV_KEYWORD = '_cfv';
@@ -8919,6 +8930,14 @@ function Ktl($, appInfo) {
                 })
 
             },
+            stickTableHeaders: function (viewId, data, numOfRecords, viewHeight) {
+                if (data.length < numOfRecords) return;
+                $(`#${viewId} table, #${viewId} .kn-table-wrapper`)
+                    .addClass('ktlStickyHeader')
+                    .css('height', viewHeight + 'px')
+                    .find('th')
+                    .css({'position': 'sticky', 'top': '-2px', 'z-index': '10'});
+            }
         }
     })(); //Views feature
 

--- a/KTL.js
+++ b/KTL.js
@@ -5265,6 +5265,7 @@ function Ktl($, appInfo) {
                     keywords._hsc && ktl.views.hideShowColumns(viewId, keywords);
                     keywords._dl && ktl.views.disableLinks(viewId, keywords);
                     keywords._sth && makeTableHeaderSticky(viewId, keywords, data);
+                    keywords._stc && makeTableColumnSticky(viewId, keywords);
                 }
 
                 //This section is for keywords that are supported by views and fields.
@@ -5630,6 +5631,17 @@ function Ktl($, appInfo) {
                 
             }
             ktl.views.stickTableHeaders(viewId, data, numOfRecords, viewHeight);
+        }
+        /* _stc = Make First col in table sticky
+        * @param {string} viewId - The view.key
+        * @param {object} keywords - The keywords object*/
+        function makeTableColumnSticky(viewId, keywords) {
+            const kw = '_stc';
+            let stickyBkgdColor = 'rgb(243 246 249)';
+            if (keywords[kw] && keywords[kw][0]?.params && keywords[kw][0]?.params[0].length) {
+                stickyBkgdColor = keywords[kw][0].params[0][0];
+            }
+            ktl.views.stickFirstColumn(viewId, stickyBkgdColor);
         }
         /////////////////////////////////////////////////////////////////////////////////
         function colorizeFieldByValue(viewId, data) {
@@ -8937,7 +8949,11 @@ function Ktl($, appInfo) {
                     .css('height', viewHeight + 'px')
                     .find('th')
                     .css({'position': 'sticky', 'top': '-2px', 'z-index': '10'});
-            }
+            },
+            stickFirstColumn: function (viewId, stickyBkgdColor) {
+                $(`#${viewId} thead tr th:first-child`).addClass('ktlStickyColumn').css({'z-index': '50', 'position': 'sticky', 'left': '-1px'}); //make first col sticky
+                $(`#${viewId} tbody tr td:first-child`).addClass('ktlStickyColumn').css({'z-index': '20', 'position': 'sticky', 'left': '-1px','background-color': stickyBkgdColor}); //make first col sticky;
+            },
         }
     })(); //Views feature
 


### PR DESCRIPTION
Added the new keywords _stc & _sth
_sth takes 2 parameters minimum num of records the table needs before header is sticky and height of the table.  you don't need the params as defaults are 10 records and 800px height
_stc makes the first column sticky this takes a colour as a parameter but not needed as its default is set to a really light blue