### PR TITLE
Fix tooltip positioning and styling

### DIFF
--- a/KTL.css
+++ b/KTL.css
@@ -325,7 +325,6 @@ a.ktlSortDisabled {
 .ktlTooltip {
 	display: none;
 	font-weight: 400;
-	position: absolute;
 	text-align: left;
 	border: 1px solid #000000;
 	border-radius: 5px;

--- a/KTL.css
+++ b/KTL.css
@@ -323,6 +323,7 @@ a.ktlSortDisabled {
 
 /* Set the tooltip text styles */
 .ktlTooltip {
+	display: none;
 	font-weight: 400;
 	position: absolute;
 	text-align: left;

--- a/KTL.js
+++ b/KTL.js
@@ -12025,11 +12025,12 @@ function Ktl($, appInfo) {
                     }
                 }
 
-                // Create the tooltip element once and reuse it
-                const tooltipElement = $(`<div class="ktlTooltip ktlTtip-${viewType}-view">${tooltipText}</div>`).appendTo('body');
-
                 // Add event listeners directly to the elements that need them
                 $(`${tooltipIconPosition} i.${tooltipIcon}`).on('mouseenter.ktlTooltip', function (e) {
+                    const icon = $(this);
+
+                    // Create the tooltip element once and reuse it
+                    const tooltipElement = $(`<div class="ktlTooltip ktlTtip-${viewType}-view">${tooltipText}</div>`).appendTo('body');
                     const tooltipWidth = tooltipElement.outerWidth();
                     const tooltipHeight = tooltipElement.outerHeight();
 
@@ -12054,11 +12055,15 @@ function Ktl($, appInfo) {
                         zIndex: 2000
                     });
 
-                    // Show the tooltip
+                    icon.data('tooltipElement', tooltipElement);
+
                     tooltipElement.show();
                 }).on('mouseleave.ktlTooltip', function () {
-                    // Hide the tooltip
-                    tooltipElement.hide();
+                    const icon = $(this);
+                    // Retrieve the tooltipElement from the icon
+                    const tooltipElement = icon.data('tooltipElement')
+
+                    tooltipElement.remove();
                 });
             },
 

--- a/KTL.js
+++ b/KTL.js
@@ -12025,11 +12025,9 @@ function Ktl($, appInfo) {
                     }
                 }
 
-                // Add event listeners directly to the elements that need them
                 $(`${tooltipIconPosition} i.${tooltipIcon}`).on('mouseenter.ktlTooltip', function (e) {
                     const icon = $(this);
 
-                    // Create the tooltip element once and reuse it
                     const tooltipElement = $(`<div class="ktlTooltip ktlTtip-${viewType}-view">${tooltipText}</div>`).appendTo('body');
                     const tooltipWidth = tooltipElement.outerWidth();
                     const tooltipHeight = tooltipElement.outerHeight();

--- a/KTL.js
+++ b/KTL.js
@@ -12025,38 +12025,40 @@ function Ktl($, appInfo) {
                     }
                 }
 
-                $(document).on('mouseenter', `${tooltipIconPosition} i.${tooltipIcon}`, function (e) {
-                    if (!$('.ktlTooltip').length) {
-                        const tooltipElement = $(`<div class="ktlTooltip ktlTtip-${viewType}-view">${tooltipText}</div>`);
-                        tooltipElement.appendTo('body');
+                // Create the tooltip element once and reuse it
+                const tooltipElement = $(`<div class="ktlTooltip ktlTtip-${viewType}-view">${tooltipText}</div>`).appendTo('body');
 
-                        const tooltipWidth = tooltipElement.outerWidth();
-                        const tooltipHeight = tooltipElement.outerHeight();
+                // Add event listeners directly to the elements that need them
+                $(`${tooltipIconPosition} i.${tooltipIcon}`).on('mouseenter.ktlTooltip', function (e) {
+                    const tooltipWidth = tooltipElement.outerWidth();
+                    const tooltipHeight = tooltipElement.outerHeight();
 
-                        let tooltipLeft = e.clientX - tooltipWidth / 2;
-                        let tooltipTop = e.clientY - tooltipHeight - 20;
+                    let tooltipLeft = e.clientX - tooltipWidth / 2;
+                    let tooltipTop = e.clientY - tooltipHeight - 20;
 
-                        if (tooltipLeft < 0) {
-                            tooltipLeft = 10;
-                        } else if (tooltipLeft + tooltipWidth > $(window).width()) {
-                            tooltipLeft = $(window).width() - tooltipWidth - 10;
-                        }
-
-                        if (tooltipTop < 0) {
-                            tooltipTop = e.clientY + 20;
-                        }
-
-                        tooltipElement.css({
-                            position: 'fixed',
-                            left: tooltipLeft + 'px',
-                            top: tooltipTop + 'px',
-                            zIndex: 1000
-                        });
+                    if (tooltipLeft < 0) {
+                        tooltipLeft = 10;
+                    } else if (tooltipLeft + tooltipWidth > $(window).width()) {
+                        tooltipLeft = $(window).width() - tooltipWidth - 10;
                     }
-                });
 
-                $(document).on('mouseleave', `${tooltipIconPosition} i.${tooltipIcon}`, function () {
-                    $('.ktlTooltip').remove();
+                    if (tooltipTop < 0) {
+                        tooltipTop = e.clientY + 20;
+                    }
+
+                    // Set the style properties directly on the element's style object
+                    Object.assign(tooltipElement[0].style, {
+                        position: 'fixed',
+                        left: tooltipLeft + 'px',
+                        top: tooltipTop + 'px',
+                        zIndex: 2000
+                    });
+
+                    // Show the tooltip
+                    tooltipElement.show();
+                }).on('mouseleave.ktlTooltip', function () {
+                    // Hide the tooltip
+                    tooltipElement.hide();
                 });
             },
 


### PR DESCRIPTION
This pull request fixes the positioning and styling of tooltips. This PR adds event listeners directly to the elements that need them and creates the tooltip element once and reuses it. It also sets the style properties directly on the element's style object and shows/hides the tooltip accordingly.