### PR TITLE
Changed getting the view type to ktl.views.getViewType

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -11451,7 +11451,7 @@ function Ktl($, appInfo) {
                     return;
 
                 const view = Knack.views[viewId];
-                const viewType = view.type;
+                const viewType = ktl.views.getViewType(viewId);
                 let columns;
                 if (viewType === 'search')
                     columns = view.model.results_model.view.columns;


### PR DESCRIPTION
When _hc was in a search view the viewType in hideTableColumns was undefined so I have changed the way we get the view type