### PR TITLE
Added exception addLongClickListener for input, textarea, signature and rich text editor

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -20706,6 +20706,13 @@ function addLongClickListener(selector, callback, duration = 500, needFirstClick
         function handleMouseDown(event) {
             if (needFirstClick && !clickOccurred) return;
 
+            // Check if the target is an input element
+            if (
+                $(event.target).is('input, textarea') ||
+                $(event.target).closest('.kn-signature').length ||
+                $(event.target).closest('.redactor-editor').length
+            ) return;
+
             startPosition.x = event.pageX;
             startPosition.y = event.pageY;
 


### PR DESCRIPTION
Adding this because some of our users have lost significant data when spell checking and when using the signature box.