### PR TITLE
Updates cell title for nested spans

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -15731,7 +15731,7 @@ function Ktl($, appInfo) {
                                             const innerSpanTexts = addressSpans.map(function() {
                                                 return $(this).text().trim();
                                             }).get().filter(Boolean);
-                                            titleText = innerSpanTexts.length > 1 ? innerSpanTexts.join(', ') : innerSpanTexts.join('');
+                                            titleText = innerSpanTexts.join(', ');
                                         } else {
                                             // No child spans, use the span's own text
                                             titleText = $span.text().trim();

--- a/KTL.js
+++ b/KTL.js
@@ -15720,21 +15720,32 @@ function Ktl($, appInfo) {
 
                                 $(selector).each(function() {
                                     const $span = $(this);
-                                    const fullText = $span.text().trim();
                                     const $tdParent = $span.closest('td');
-
-                                    // Only add title if it doesn't already exist or is different from fullText
-                                    const existingTitle = $tdParent.attr('title');
-                                    if (!existingTitle || existingTitle !== fullText) {
-                                        $tdParent.attr('title', fullText);
+                                
+                                    // Only process the outer span (the one that contains all address spans)
+                                    if ($span.parent().is('td')) {
+                                        // Get all direct child spans (the addresses)
+                                        const addressSpans = $span.children('span');
+                                        const innerSpanTexts = addressSpans.map(function() {
+                                            return $(this).text().trim();
+                                        }).get().filter(Boolean);
+                                
+                                        // Use comma if more than one, else just join as is
+                                        const allText = innerSpanTexts.length > 1 ? innerSpanTexts.join(', ') : innerSpanTexts.join('');
+                                
+                                        // Only add title if it doesn't already exist or is different from allText
+                                        const existingTitle = $tdParent.attr('title');
+                                        if (!existingTitle || existingTitle !== allText) {
+                                            $tdParent.attr('title', allText);
+                                        }
                                     }
-
+                                
                                     // Apply truncation styles if not already applied
                                     if (!$span.hasClass('ktlTruncateCellText')) {
                                         $span.addClass('ktlTruncateCellText')
-                                             .css({
-                                                 'max-width': widthAmount + 'px',
-                                             });
+                                            .css({
+                                                'max-width': widthAmount + 'px',
+                                            });
                                     }
                                 });
                             }

--- a/KTL.js
+++ b/KTL.js
@@ -15721,25 +15721,28 @@ function Ktl($, appInfo) {
                                 $(selector).each(function() {
                                     const $span = $(this);
                                     const $tdParent = $span.closest('td');
-                                
-                                    // Only process the outer span (the one that contains all address spans)
+
                                     if ($span.parent().is('td')) {
                                         // Get all direct child spans (the addresses)
                                         const addressSpans = $span.children('span');
-                                        const innerSpanTexts = addressSpans.map(function() {
-                                            return $(this).text().trim();
-                                        }).get().filter(Boolean);
-                                
-                                        // Use comma if more than one, else just join as is
-                                        const allText = innerSpanTexts.length > 1 ? innerSpanTexts.join(', ') : innerSpanTexts.join('');
-                                
-                                        // Only add title if it doesn't already exist or is different from allText
+                                        let titleText = '';
+
+                                        if (addressSpans.length > 0) {
+                                            const innerSpanTexts = addressSpans.map(function() {
+                                                return $(this).text().trim();
+                                            }).get().filter(Boolean);
+                                            titleText = innerSpanTexts.length > 1 ? innerSpanTexts.join(', ') : innerSpanTexts.join('');
+                                        } else {
+                                            // No child spans, use the span's own text
+                                            titleText = $span.text().trim();
+                                        }
+
                                         const existingTitle = $tdParent.attr('title');
-                                        if (!existingTitle || existingTitle !== allText) {
-                                            $tdParent.attr('title', allText);
+                                        if (!existingTitle || existingTitle !== titleText) {
+                                            $tdParent.attr('title', titleText);
                                         }
                                     }
-                                
+
                                     // Apply truncation styles if not already applied
                                     if (!$span.hasClass('ktlTruncateCellText')) {
                                         $span.addClass('ktlTruncateCellText')

--- a/KTL.js
+++ b/KTL.js
@@ -15724,11 +15724,11 @@ function Ktl($, appInfo) {
 
                                     if ($span.parent().is('td')) {
                                         // Get all direct child spans (the addresses)
-                                        const addressSpans = $span.children('span');
+                                        const tdSpans = $span.children('span');
                                         let titleText = '';
 
-                                        if (addressSpans.length > 0) {
-                                            const innerSpanTexts = addressSpans.map(function() {
+                                        if (tdSpans.length > 0) {
+                                            const innerSpanTexts = tdSpans.map(function() {
                                                 return $(this).text().trim();
                                             }).get().filter(Boolean);
                                             titleText = innerSpanTexts.join(', ');


### PR DESCRIPTION
Updates the title attribute for table cells containing nested spans, specifically addressing connection fields.

Instead of using the entire text content of the outer span, it now extracts and joins the text from the direct child spans, separated by commas if multiple spans are present. This ensures a more accurate and relevant title for connection fields.