### PR TITLE
Improves print view and sort icon layering

### DIFF
--- a/KTL.css
+++ b/KTL.css
@@ -339,7 +339,6 @@ a.ktlSortDisabled {
     border: none;
     cursor: pointer;
     font-size: 16px;
-    z-index: 10;
 }
 
 /* Helper Text */

--- a/KTL.css
+++ b/KTL.css
@@ -756,7 +756,7 @@ body.ktlKioskMode { /* Add extra space at top of screen in kiosk mode, to preven
 	#addVersionInfoDiv,
 	.bulkEditCb,
 	.ktlBookmarksContainer {
-		display: none;
+		display: none !important;
 	}
 
 	.cell-editable td.cell-edit {

--- a/KTL.css
+++ b/KTL.css
@@ -339,7 +339,7 @@ a.ktlSortDisabled {
     border: none;
     cursor: pointer;
     font-size: 16px;
-    z-index: 2001;
+    z-index: 10;
 }
 
 /* Helper Text */
@@ -754,7 +754,9 @@ body.ktlKioskMode { /* Add extra space at top of screen in kiosk mode, to preven
 }
 
 @media print {
-	#addVersionInfoDiv, .bulkEditCb {
+	#addVersionInfoDiv,
+	.bulkEditCb,
+	.ktlBookmarksContainer {
 		display: none;
 	}
 


### PR DESCRIPTION
Improves print view by hiding the bookmarks container, preventing it from being printed.

Reduces the z-index of the bookmark container. This prevents it from overlapping with other elements on the page.