### PR TITLE
Fix: Prevent error when removing search filter options in many-to-many connection fields

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -3432,7 +3432,10 @@ function Ktl($, appInfo) {
         $(document).on('KTL.persistentForm.completed.scene', function (event, viewOrScene) {
             //This is required because when removing the last option from a multiple selection dropdown, the change event is not fired.
             $('.search-choice-close').off('click.ktl_removeoption').bindFirst('click.ktl_removeoption', function (e) {
-                const [viewId, fieldId] = $(e.target).closest('.kn-input').find('.chzn-select').attr('id').split('-');
+                const selectId = $(e.target).closest('.kn-input').find('.chzn-select').attr('id');
+                if (!selectId) return; // Skip if not a form input (e.g., search filters)
+
+                const [viewId, fieldId] = selectId.split('-');
 
                 setTimeout(() => {
                     const options = $(e.target).closest('.kn-input-connection').find('.chzn-select [value]').toArray();


### PR DESCRIPTION
When users navigate to a bookmarked or copied URL that contains search filters from a many-to-many connection field, and then attempt to click the 'x' button to remove filter options, KTL's persistent form handler crashes with: "Cannot read properties of undefined (reading 'split')"

Root Cause:
KTL's persistent form handler uses a selector that attaches a click handler to ALL .search-choice-close elements (the 'x' buttons). The handler then attempts to find a .chzn-select element inside a .kn-input container and extract its ID. However, search filter dropdowns have a different DOM structure than form field dropdowns - the search filter .search-choice-close elements don't have a .chzn-select inside a .kn-input. When the handler tries to call .attr('id').split('-') on undefined, it crashes.

How to Reproduce:
1. Navigate to a Search Table view
2. In the search inputs, select options from a many-to-many connection field
3. Click Search to apply the filter
4. Bookmark the page or copy the URL
5. Navigate away and return to the bookmarked/copied URL
6. Try clicking the 'x' button on any of the filter options
7. Error occurs: Cannot read properties of undefined (reading 'split')

Solution:
Add a safety check in the persistent form handler's click listener. Store the selectId in a variable and verify it exists before attempting to split it. If selectId is undefined (indicating a search filter rather than a form dropdown), simply return early and skip processing.

This allows search filter removal to work correctly while maintaining existing functionality for form field dropdowns.