### PR TITLE
Major refactor fo loadFormData. _rlv now reloads  last values whether a user has changed them or not.  Connection fields now reliably load last values.  Added multiple retries to make sure.

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -4753,6 +4753,10 @@ function Ktl($, appInfo) {
     //Will automatically save and load form data to prevent losses after a refresh, power outage, network loss or other.
     this.persistentForm = (function () {
         const PERSISTENT_FORM_DATA = 'persistentForm';
+        const MAX_CONNECTION_HYDRATE_RETRIES = 6;
+        const CONNECTION_HYDRATE_RETRY_DELAY = 500;
+        const CONNECTION_EVENT_WAIT_TIMEOUT = 5000;
+        const connectionHydrationQueue = new Map();
         //To see all data types:  console.log(Knack.config);
 
         //Add fields and scenes to exclude from persistence in these arrays.
@@ -5071,19 +5075,42 @@ function Ktl($, appInfo) {
         //If a viewId is supplied, only this form will be processed, otherwise all forms in scene.
         //Also adds Change event handlers for dropdowns and calendars.   Eventually, support all object types.
         //After loading, re-validates numeric fields and highlights errors in pink.
-        let allViewsDone = [];
+        let viewLoadPromises = new Map();
+
+        function parsePersistentFormStorage() {
+            const storedData = ktl.storage.lsGetItem(PERSISTENT_FORM_DATA);
+            if (!storedData) return null;
+
+            try {
+                return JSON.parse(storedData);
+            } catch (error) {
+                console.error('Persistent Form - unable to parse stored data, clearing cache.', error);
+                ktl.storage.lsRemoveItem(PERSISTENT_FORM_DATA);
+                return null;
+            }
+        }
+
+        function persistFormDataCache(data) {
+            if (!data || $.isEmptyObject(data)) {
+                ktl.storage.lsRemoveItem(PERSISTENT_FORM_DATA);
+            } else {
+                ktl.storage.lsSetItem(PERSISTENT_FORM_DATA, JSON.stringify(data));
+            }
+        }
         function loadFormData(viewId) {
-            return new Promise(function (resolve) {
-                if (allViewsDone.length) return resolve(); //Prevent re-entry until finished.
+            function markViewLoaded(targetViewId) {
+                if (!targetViewId) return;
+                $(`#${targetViewId}`).addClass('ktlPersistenFormLoadedView');
+                $(document).trigger(`KTL.persistentForm.completed.view.${targetViewId}`, targetViewId);
+            }
 
-                var formDataObjStr = ktl.storage.lsGetItem(PERSISTENT_FORM_DATA);
+            return new Promise((resolve) => {
+                const parsedFormData = parsePersistentFormStorage();
 
-                //If nothing to load, just skip the rest and declare the view and scene as loaded and ready for further processing.
-                if (!formDataObjStr || $.isEmptyObject(JSON.parse(formDataObjStr))) {
-                    ktl.storage.lsRemoveItem(PERSISTENT_FORM_DATA); //Wipe out if empty object, JIC.
+                if (!parsedFormData || $.isEmptyObject(parsedFormData)) {
+                    persistFormDataCache(null);
                     if (viewId) {
-                        $(`#${viewId}`).addClass('ktlPersistenFormLoadedView');
-                        $(document).trigger(`KTL.persistentForm.completed.view.${viewId}`, viewId);
+                        markViewLoaded(viewId);
                     } else {
                         $('.kn-scene').addClass('ktlPersistenFormLoadedScene');
                         $(document).trigger('KTL.persistentForm.completed.scene', [Knack.router.scene_view.model]);
@@ -5091,205 +5118,428 @@ function Ktl($, appInfo) {
                     return resolve();
                 }
 
-                const formDataObj = {};
                 currentViews = {};
 
-                if (viewId) {
-                    const view = Knack.router.scene_view.model.views._byId[viewId];
-                    if (view && view.attributes)
-                        loadDataForView(view.attributes)
-                            .then(() => {
-                                if (view.attributes.type === 'form' && (view.attributes.action === 'insert' || view.attributes.action === 'create')) {
-                                    $(`#${view.attributes.key}`).addClass('ktlPersistenFormLoadedView');
-                                    $(document).trigger(`KTL.persistentForm.completed.view.${view.attributes.key}`, view.attributes.key);
-                                    return resolve();
-                                }
-                            })
-                } else {
-                    //All views in scene.
-                    Knack.router.scene_view.model.views.models.map(model => model.attributes).forEach(view => {
-                        allViewsDone.push(
-                            loadDataForView(view)
-                                .then(() => {
-                                    if (view.type === 'form' && (view.action === 'insert' || view.action === 'create')) {
-                                        $(`#${view.key}`).addClass('ktlPersistenFormLoadedView');
-                                        $(document).trigger(`KTL.persistentForm.completed.view.${view.key}`, view.key);
-                                    }
-                                })
-                        );
-                    })
+                const targetViews = getTargetViews(viewId);
+                if (!targetViews.length) return resolve();
 
-                    Promise.all(allViewsDone)
-                        .then(() => {
-                            allViewsDone = [];
-                            resolve();
-                        })
+                const loadPromises = targetViews.map(viewAttr => ensureViewLoadPromise(viewAttr, parsedFormData, markViewLoaded));
+                Promise.all(loadPromises).then(() => resolve());
+            });
+
+            function getTargetViews(targetViewId) {
+                const sceneView = Knack.router.scene_view;
+                if (!sceneView || !sceneView.model || !sceneView.model.views) return [];
+
+                if (targetViewId) {
+                    const viewModel = sceneView.model.views._byId[targetViewId];
+                    return (viewModel && viewModel.attributes) ? [viewModel.attributes] : [];
                 }
 
-                function loadDataForView(view) {
-                    return new Promise(function (resolve) {
-                        if (view.type !== 'form') return resolve();
+                return sceneView.model.views.models
+                    .map(model => model && model.attributes)
+                    .filter(Boolean);
+            }
 
-                        //Add only, not Edit or any other type
-                        if (view.action != 'insert' && view.action != 'create')
-                            return resolve();
+            function ensureViewLoadPromise(viewAttr, parsedFormData, markLoaded) {
+                if (!viewAttr) return Promise.resolve();
 
-                        const viewData = JSON.parse(formDataObjStr)[view.key];
-                        if (!viewData) return resolve();
+                const existingLoad = viewLoadPromises.get(viewAttr.key);
+                if (existingLoad) return existingLoad;
 
-                        const pfTimeout = setTimeout(function () { //Failsafe
-                            console.log('loadDataForView timeout expired.', viewId, pfTimeout);
-                            return resolve();
-                        }, 20000);
+                const loadPromise = loadDataForView(viewAttr, parsedFormData)
+                    .then(() => {
+                        if (viewAttr.type === 'form' && (viewAttr.action === 'insert' || viewAttr.action === 'create')) {
+                            markLoaded(viewAttr.key);
+                        }
+                    })
+                    .finally(() => {
+                        viewLoadPromises.delete(viewAttr.key);
+                    });
 
-                        currentViews[view.key] = view.key;
-                        formDataObj[view.key] = viewData;
+                viewLoadPromises.set(viewAttr.key, loadPromise);
+                return loadPromise;
+            }
 
-                        if (formDataObj[view.key] && formDataObj[view.key].expiryDate && new Date(formDataObj[view.key].expiryDate) < new Date()) {
-                            delete formDataObj[view.key];
-                            ktl.storage.lsSetItem(PERSISTENT_FORM_DATA, JSON.stringify(formDataObj));
-                            return resolve();
+            function loadDataForView(viewAttr, parsedFormData) {
+                return new Promise((resolve) => {
+                    if (!viewAttr || viewAttr.type !== 'form') return resolve();
+                    if (viewAttr.action !== 'insert' && viewAttr.action !== 'create') return resolve();
+
+                    const storedViewData = parsedFormData[viewAttr.key];
+                    if (!storedViewData) return resolve();
+
+                    const pfTimeout = setTimeout(() => {
+                        console.log('loadDataForView timeout expired.', viewAttr.key);
+                        finish();
+                    }, 20000);
+
+                    let finished = false;
+                    const finish = () => {
+                        if (finished) return;
+                        finished = true;
+                        clearTimeout(pfTimeout);
+                        resolve();
+                    };
+
+                    currentViews[viewAttr.key] = viewAttr.key;
+
+                    const hasReloadLastValues = Boolean(ktlKeywords[viewAttr.key] && ktlKeywords[viewAttr.key]._rlv);
+
+                    if (storedViewData.expiryDate && new Date(storedViewData.expiryDate) < new Date()) {
+                        delete parsedFormData[viewAttr.key];
+                        persistFormDataCache(parsedFormData);
+                        return finish();
+                    }
+
+                    const targetViewId = viewAttr.key;
+                    const keys = Object.keys(storedViewData).filter(key => key !== 'expiryDate');
+                    for (const fieldKey of keys) {
+                        const fieldIdMatch = fieldKey.match(/field_\d+/);
+                        const fieldId = fieldIdMatch ? fieldIdMatch[0] : null;
+
+                        if (fieldsToExclude.includes(fieldId)) {
+                            ktl.log.clog('purple', 'Skipped field for PF: ' + fieldId);
+                            continue;
                         }
 
-                        const keys = Object.keys(formDataObj[view.key]).filter(key => key !== 'expiryDate');
-                        for (const fieldKey of keys) {
-                            const fieldIdMatch = fieldKey.match(/field_\d+/);
-                            const fieldId = fieldIdMatch ? fieldIdMatch[0] : null;
+                        const field = fieldId ? Knack.objects.getField(fieldId) : null;
+                        if (!field) continue;
 
-                            if (fieldsToExclude.includes(fieldId)) {
-                                ktl.log.clog('purple', 'Skipped field for PF: ' + fieldId);
-                                continue; //JIC - should never happen since fieldsToExclude are never saved in the first place.
-                            }
+                        const fieldType = field.attributes.type;
+                        let fieldValue = storedViewData[fieldKey] || storedViewData[fieldId];
 
-                            const field = fieldId ? Knack.objects.getField(fieldId) : null;
-                            if (!field) continue;
+                        if (fieldType === 'rich_text') {
+                            hydrateRichTextField({ fieldId, fieldValue, viewId: targetViewId });
+                        } else if (TEXT_DATA_TYPES.includes(fieldType)) {
+                            hydrateTextField({ fieldId, fieldKey, fieldValue, viewId: targetViewId, field, formDataObj: parsedFormData, preserveFieldData: hasReloadLastValues });
+                        } else if (fieldType === 'connection') {
+                            hydrateConnectionField({ fieldId, fieldValue, viewId: targetViewId, formDataObj: parsedFormData });
+                        } else if (fieldType === 'multiple_choice') {
+                            hydrateMultipleChoiceField({ fieldId, fieldValue, viewId: targetViewId, field });
+                        } else if (fieldType === 'boolean') {
+                            hydrateBooleanField({ fieldId, fieldValue, viewId: targetViewId, field });
+                        } else if (['password', 'file', 'image'].includes(fieldType)) {
+                            //Ignore.
+                        } else {
+                            ktl.log.clog('purple', 'Unsupported field type: ' + fieldId + ', ' + fieldType);
+                        }
 
-                            let subField = '';
-                            const fieldType = field.attributes.type;
-                            let fieldText = formDataObj[view.key][fieldKey] || formDataObj[view.key][fieldId]; //fieldKey is required for Date/Time suffixes.
+                        if (!hasReloadLastValues) {
+                            delete storedViewData[fieldKey];
+                        }
+                    }
 
-                            if (fieldType === 'rich_text') {
-                                $(`#${view.key} #${fieldId}`).data('redactor').code.set(fieldText);
-                            } else if (TEXT_DATA_TYPES.includes(fieldType)) {
-                                const setFieldText = (subField) => {
-                                    const selectElement = $(`#${view.key} [data-input-id=${fieldId}] select[name="${subField}"]`);
+                    if (!hasReloadLastValues) {
+                        delete parsedFormData[targetViewId];
+                    }
 
-                                    if (selectElement.length) {
-                                        selectElement.val(fieldText);
-                                        return;
-                                    }
+                    persistFormDataCache(parsedFormData);
+                    finish();
+                });
+            }
+        }
 
-                                    let el;
-                                    if (fieldType === 'date_time' || fieldType === 'timer')
-                                        el = document.querySelector(`#${viewId}-${fieldKey}`);
-                                    else {
-                                        const selector1 = `#${view.key} [data-input-id=${fieldId}] #${subField}.input`;
-                                        const selector2 = `#${view.key} [data-input-id=${fieldId}] input`;
-                                        const selector3 = `#${view.key} [data-input-id=${fieldId}] .kn-textarea`;
+        function hydrateRichTextField({ fieldId, fieldValue, viewId }) {
+            const editor = $(`#${viewId} #${fieldId}`);
+            if (!editor.length) return;
+            editor.data('redactor').code.set(fieldValue);
+        }
 
-                                        el = document.querySelector(selector1) || document.querySelector(selector2) || document.querySelector(selector3);
-                                    }
+        function hydrateTextField({ fieldId, fieldKey, fieldValue, viewId, field, formDataObj, preserveFieldData = false }) {
+            const viewElement = document.getElementById(viewId);
+            if (!viewElement) return;
+            const fieldContainer = viewElement.querySelector(`[data-input-id="${fieldId}"]`);
+            if (!fieldContainer) return;
 
-                                    if (el)
-                                        $(el).val(fieldText);
-                                }
-
-                                if (typeof fieldText === 'object') {
-                                    //If we have an object instead of plain text, we need to recurse into it for each sub-field.
-                                    //Ex: name and address field types.
-                                    const allSubFields = Object.keys(formDataObj[view.key][fieldId]);
-                                    allSubFields.forEach(function (eachSubField) {
-                                        fieldText = formDataObj[view.key][fieldId][eachSubField];
-                                        setFieldText(eachSubField);
-                                        delete formDataObj[view.key][fieldId][eachSubField];
-                                    })
-                                } else {
-                                    setFieldText();
-                                    delete formDataObj[view.key][fieldKey];
-                                }
-                            } else if (fieldType === 'connection') {
-                                if (typeof fieldText === 'object') {
-                                    subField = Object.keys(formDataObj[view.key][fieldId]);
-                                    fieldText = formDataObj[view.key][fieldId][subField];
-                                }
-
-                                if ($(`#${view.key}-${fieldId}`).hasClass('chzn-select')) {
-                                    const options = fieldText.split(';').map(record => {
-                                        const [label, id] = record.split(':');
-                                        return { label, id };
-                                    }).filter(v => !!v.id && ktl.core.hasRecordIdFormat(v.id));
-
-                                    const input = $(`#${view.key}-${fieldId}`);
-
-                                    options.forEach(option => {
-                                        if (!input.find(`option[value="${option.id}"]`).length) {
-                                            input.append(`<option value="${option.id}">${option.label}</option>`);
-                                        }
-                                    });
-
-                                    const values = input.val() || [];
-                                    input.val([...values, ...options.map(o => o.id)]).trigger("liszt:updated");
-                                } else if ($(`#${view.key} #connection-picker-radio-${fieldId}`).length) { // Radio buttons
-                                    $(`#${view.key} #connection-picker-radio-${fieldId} input[value="${fieldText}"]`).click();
-                                } else if ($(`#${view.key} #connection-picker-checkbox-${fieldId}`).length) { // Checkboxes
-                                    //Wait until finished loading.
-                                    ktl.core.waitSelector(`#${viewId} #connection-picker-checkbox-${fieldId} span:textEquals("loading...")`, 10000, 'none')
-                                        .then(() => {
-                                            const values = fieldText.split(',');
-                                            for (const value of values) {
-                                                if (!$(`#${view.key} #connection-picker-checkbox-${fieldId} input[value="${value}"]`)[0].checked)
-                                                    $(`#${view.key} #connection-picker-checkbox-${fieldId} input[value="${value}"]`).click();
-                                            }
-                                        })
-                                        .catch(() => { })
-                                }
-                            } else if (fieldType === 'multiple_choice') {
-                                if (typeof fieldText === 'object') {
-                                    Object.keys(formDataObj[view.key][fieldId]).forEach(subField => {
-                                        const value = formDataObj[view.key][fieldId][subField];
-                                        $(`#${subField}`).val(value);
-                                    })
-                                } else if (field.attributes.format.type === 'radios') {
-                                    $(`#${view.key} #kn-input-${fieldId} [value="${fieldText}"]`).click();
-                                } else if (field.attributes.format.type === 'checkboxes') {
-                                    const options = JSON.parse(fieldText);
-                                    Object.keys(options).forEach(key => {
-                                        const option = $(`#${view.key} [data-input-id="${fieldId}"] input[value="${key}"]`).first();
-                                        if (options[key] != option.prop('checked')) {
-                                            option.click();
-                                        }
-                                    })
-                                } else {
-                                    const values = $(`#${view.key}-${fieldId}`).val() || [];
-                                    const choices = fieldText.split(';').map(choice => choice.split(':')[0])
-                                    $(`#${view.key}-${fieldId}`).val([...values, ...choices]).trigger("liszt:updated");
-                                }
-                            } else if (fieldType === 'boolean') {
-                                if (field.attributes.format.input === 'checkbox') {
-                                    if (fieldText === 'true')
-                                        $(`#${view.key} [data-input-id="${fieldId}"] input`).first().click();
-                                } else if (field.attributes.format.input === 'radios')
-                                    $(`#${view.key} [data-input-id="${fieldId}"] input[value="${fieldText}"]`).first().click();
-                                else {
-                                    $(`#${view.key} [data-input-id="${fieldId}"] option`).removeAttr('selected');
-                                    $(`#${view.key} [data-input-id="${fieldId}"] option[value=${fieldText}]`).attr('selected', 'selected');
-                                    $(`#${view.key} select#${fieldId}.select`).trigger('change');
-                                }
-                            } else if (['password', 'file', 'image'].includes(fieldType)) {
-                                //Ignore.
-                            } else {
-                                ktl.log.clog('purple', 'Unsupported field type: ' + fieldId + ', ' + fieldType);
-                            }
-
-                            delete formDataObj[view.key][fieldKey];
-                        };
-
-                        clearTimeout(pfTimeout);
-                        delete formDataObj[view.key];
-                        return resolve();
-                    })
+            const setFieldText = (subField = '') => {
+                if (subField) {
+                    const selectElement = fieldContainer.querySelector(`select[name="${subField}"]`);
+                    if (selectElement) {
+                        selectElement.value = fieldValue;
+                        return;
+                    }
                 }
-            })
+
+                let element;
+                if (field.attributes.type === 'date_time' || field.attributes.type === 'timer') {
+                    element = document.querySelector(`#${viewId}-${fieldKey}`);
+                } else {
+                    if (subField) {
+                        const escapedSubField = escapeForAttribute(subField);
+                        element = fieldContainer.querySelector(`#${escapedSubField}.input`) ||
+                            fieldContainer.querySelector(`#${escapedSubField}`);
+                    }
+
+                    if (!element) {
+                        element = fieldContainer.querySelector('input') ||
+                            fieldContainer.querySelector('.kn-textarea');
+                    }
+                }
+
+                if (element) {
+                    if ('value' in element) {
+                        element.value = fieldValue;
+                    } else {
+                        element.textContent = fieldValue;
+                    }
+                }
+            };
+
+            if (typeof fieldValue === 'object') {
+                const subFields = Object.keys(formDataObj[viewId][fieldId] || {});
+                subFields.forEach(subField => {
+                    fieldValue = formDataObj[viewId][fieldId][subField];
+                    setFieldText(subField);
+                    if (!preserveFieldData) {
+                        delete formDataObj[viewId][fieldId][subField];
+                    }
+                });
+            } else {
+                setFieldText();
+                if (!preserveFieldData && formDataObj[viewId]) {
+                    delete formDataObj[viewId][fieldKey];
+                }
+            }
+        }
+
+        function hydrateConnectionField({ fieldId, fieldValue, viewId, formDataObj }) {
+            if (typeof fieldValue === 'object' && formDataObj[viewId] && formDataObj[viewId][fieldId]) {
+                const [subField] = Object.keys(formDataObj[viewId][fieldId]);
+                fieldValue = subField ? formDataObj[viewId][fieldId][subField] : '';
+            }
+
+            if (!fieldValue) return;
+
+            enqueueConnectionHydration({ fieldId, fieldValue, viewId });
+        }
+
+        function hydrateMultipleChoiceField({ fieldId, fieldValue, viewId, field }) {
+            if (typeof fieldValue === 'object') {
+                Object.keys(fieldValue).forEach(subField => {
+                    const element = document.getElementById(subField);
+                    if (element) element.value = fieldValue[subField];
+                });
+            } else if (field.attributes.format.type === 'radios') {
+                const radio = document.querySelector(`#${viewId} #kn-input-${fieldId} [value="${escapeForAttribute(fieldValue)}"]`);
+                radio && radio.click();
+            } else if (field.attributes.format.type === 'checkboxes') {
+                const options = JSON.parse(fieldValue);
+                Object.keys(options).forEach(key => {
+                    const option = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttribute(key)}"]`);
+                    if (option && option.checked !== Boolean(options[key])) option.click();
+                });
+            } else {
+                const values = $(`#${viewId}-${fieldId}`).val() || [];
+                const choices = fieldValue.split(';').map(choice => choice.split(':')[0])
+                $(`#${viewId}-${fieldId}`).val([...values, ...choices]).trigger("liszt:updated");
+            }
+        }
+
+        function hydrateBooleanField({ fieldId, fieldValue, viewId, field }) {
+            if (field.attributes.format.input === 'checkbox') {
+                const checkbox = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input`);
+                if (checkbox && fieldValue === 'true' && !checkbox.checked) checkbox.click();
+            } else if (field.attributes.format.input === 'radios') {
+                const radio = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttribute(fieldValue)}"]`);
+                radio && radio.click();
+            } else {
+                const selectElement = document.querySelector(`#${viewId} select#${fieldId}.select`);
+                if (selectElement) {
+                    selectElement.value = fieldValue;
+                    selectElement.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+            }
+        }
+
+        function applyConnectionFieldValue({ fieldId, fieldValue, viewId }) {
+            if (!fieldValue) return true;
+
+            const selectSelector = `#${viewId}-${fieldId}`;
+            const select = $(selectSelector);
+            if (select.length && select.hasClass('chzn-select')) {
+                const optionStrings = ktl.core.splitAndTrimToArray(fieldValue, ';');
+                const options = optionStrings.map(record => {
+                    const [label, id] = record.split(':');
+                    return { label, id };
+                }).filter(option => option.id && ktl.core.hasRecordIdFormat(option.id));
+
+                if (!options.length) return false;
+
+                options.forEach(option => {
+                    if (!select.find(`option[value="${option.id}"]`).length) {
+                        select.append(`<option value="${option.id}">${option.label}</option>`);
+                    }
+                });
+
+                const existingValue = select.val();
+                const currentValues = Array.isArray(existingValue)
+                    ? existingValue
+                    : (existingValue ? [existingValue] : []);
+
+                const mergedValues = [...new Set([...currentValues, ...options.map(o => o.id)])];
+
+                select.val(mergedValues).trigger('liszt:updated').trigger('change');
+
+                const appliedValues = select.val();
+                const appliedArray = Array.isArray(appliedValues)
+                    ? appliedValues
+                    : (appliedValues ? [appliedValues] : []);
+
+                return mergedValues.every(value => appliedArray.includes(value));
+            }
+
+            const radioContainer = document.querySelector(`#${viewId} #connection-picker-radio-${fieldId}`);
+            if (radioContainer) {
+                const radio = radioContainer.querySelector(`input[value="${escapeForAttribute(fieldValue)}"]`);
+                if (radio) {
+                    if (!radio.checked) radio.click();
+                    return radio.checked;
+                }
+                return false;
+            }
+
+            const checkboxContainer = document.querySelector(`#${viewId} #connection-picker-checkbox-${fieldId}`);
+            if (checkboxContainer) {
+                const values = fieldValue.split(',').map(value => value.trim()).filter(Boolean);
+                if (!values.length) return true;
+
+                let success = true;
+                values.forEach(value => {
+                    const checkbox = checkboxContainer.querySelector(`input[value="${escapeForAttribute(value)}"]`);
+                    if (checkbox) {
+                        if (!checkbox.checked) checkbox.click();
+                        success = success && checkbox.checked;
+                    } else {
+                        success = false;
+                    }
+                });
+
+                return success;
+            }
+
+            const nativeSelect = document.querySelector(selectSelector);
+            if (nativeSelect) {
+                nativeSelect.value = fieldValue;
+                nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+                return nativeSelect.value === fieldValue;
+            }
+
+            return false;
+        }
+
+        function enqueueConnectionHydration({ fieldId, fieldValue, viewId }) {
+            if (!fieldValue || !viewId) return;
+
+            let state = connectionHydrationQueue.get(viewId);
+            if (!state) {
+                state = {
+                    pending: new Map(),
+                    handler: null,
+                    retryTimer: null,
+                };
+                connectionHydrationQueue.set(viewId, state);
+            }
+
+            state.pending.set(fieldId, {
+                fieldValue,
+                attempts: 0,
+                awaitingEvent: false,
+                eventDeadline: 0,
+            });
+
+            attachConnectionHydrationListener(viewId);
+            runPendingConnectionHydrations(viewId);
+        }
+
+        function runPendingConnectionHydrations(viewId, triggeredByEvent = false) {
+            const state = connectionHydrationQueue.get(viewId);
+            if (!state) return;
+
+            if (state.retryTimer) {
+                clearTimeout(state.retryTimer);
+                state.retryTimer = null;
+            }
+
+            let needsRetryTimer = false;
+
+            state.pending.forEach((entry, fieldId) => {
+                if (entry.awaitingEvent && !triggeredByEvent) {
+                    if (Date.now() >= entry.eventDeadline) {
+                        entry.awaitingEvent = false;
+                    } else {
+                        needsRetryTimer = true;
+                        return;
+                    }
+                }
+
+                const success = applyConnectionFieldValue({ fieldId, fieldValue: entry.fieldValue, viewId });
+                if (success) {
+                    if (triggeredByEvent) {
+                        state.pending.delete(fieldId);
+                    } else {
+                        entry.awaitingEvent = true;
+                        entry.eventDeadline = Date.now() + CONNECTION_EVENT_WAIT_TIMEOUT;
+                        entry.attempts = 0;
+                        needsRetryTimer = true;
+                    }
+                } else {
+                    entry.attempts += 1;
+                    if (entry.attempts >= MAX_CONNECTION_HYDRATE_RETRIES) {
+                        console.warn('Persistent Form - connection hydration exceeded retries', viewId, fieldId);
+                        state.pending.delete(fieldId);
+                    } else {
+                        needsRetryTimer = true;
+                    }
+                }
+            });
+
+            if (state.pending.size === 0) {
+                teardownConnectionHydrationState(viewId);
+                return;
+            }
+
+            if (needsRetryTimer && !state.retryTimer) {
+                state.retryTimer = setTimeout(() => {
+                    state.retryTimer = null;
+                    runPendingConnectionHydrations(viewId);
+                }, CONNECTION_HYDRATE_RETRY_DELAY);
+            }
+        }
+
+        function attachConnectionHydrationListener(viewId) {
+            const state = connectionHydrationQueue.get(viewId);
+            if (!state || state.handler) return;
+
+            const eventName = `knack-connections-load.${viewId}`;
+            const handler = () => {
+                setTimeout(() => runPendingConnectionHydrations(viewId, true), 0);
+            };
+
+            state.handler = handler;
+            $(document).on(eventName, handler);
+        }
+
+        function teardownConnectionHydrationState(viewId) {
+            const state = connectionHydrationQueue.get(viewId);
+            if (!state) return;
+
+            if (state.handler) {
+                $(document).off(`knack-connections-load.${viewId}`, state.handler);
+            }
+
+            if (state.retryTimer) {
+                clearTimeout(state.retryTimer);
+            }
+
+            connectionHydrationQueue.delete(viewId);
+        }
+
+        function escapeForAttribute(value = '') {
+            if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+                return CSS.escape(value);
+            }
+            return value.replace(/["\\]/g, '\\$&');
         }
 
         //Remove all saved data for this view after a submit

--- a/KTL.js
+++ b/KTL.js
@@ -4757,10 +4757,13 @@ function Ktl($, appInfo) {
     this.persistentForm = (function () {
         const PERSISTENT_FORM_DATA = 'persistentForm';
         const MAX_CONNECTION_HYDRATE_RETRIES = 6;
-        const CONNECTION_HYDRATE_RETRY_DELAY = 500;
+        const CONNECTION_HYDRATE_RETRY_DELAY_MIN = 100;
+        const CONNECTION_HYDRATE_RETRY_DELAY_MAX = 600;
+        const CONNECTION_HYDRATE_VERIFY_DELAY = 120;
         const FIELD_DEFINITION_CACHE = new Map();
         const CONNECTION_HYDRATION_QUEUE = new Map();
         const HYDRATING_VIEWS = new Set();
+        const PENDING_HYDRATION_SAVES = new Map();
         //To see all data types:  console.log(Knack.config);
 
         //Add fields and scenes to exclude from persistence in these arrays.
@@ -4783,6 +4786,8 @@ function Ktl($, appInfo) {
                     eraseFormData(viewId);
 
                 currentViews = {};
+                clearAllConnectionHydrationStates();
+                FIELD_DEFINITION_CACHE.clear();
             }
 
             ktl.fields.sceneConvertNumToTel().then(() => {
@@ -4946,7 +4951,10 @@ function Ktl($, appInfo) {
         function saveFormData(data, viewId, fieldId, subField) {
             // Guard clauses
             if (!pfIsInitialized || !fieldId || !viewId || !viewId.startsWith('view_')) return;
-            if (HYDRATING_VIEWS.has(viewId)) return;
+            if (HYDRATING_VIEWS.has(viewId)) {
+                queuePendingHydrationSave({ data, viewId, fieldId, subField });
+                return;
+            }
 
             const fieldType = ktl.fields.getFieldType(fieldId);
             if (!fieldType || fieldType === 'password') return;
@@ -5037,17 +5045,13 @@ function Ktl($, appInfo) {
                 formDataObj[viewId][fieldId][subField] = data;
             }
 
-            // Cleanup empty objects
+            // Cleanup empty view data
             if (Object.keys(formDataObj[viewId]).length === 0) {
                 delete formDataObj[viewId];
             }
 
-            // Save or remove data
-            if (Object.keys(formDataObj).length === 0) {
-                ktl.storage.lsRemoveItem(PERSISTENT_FORM_DATA);
-            } else {
-                ktl.storage.lsSetItem(PERSISTENT_FORM_DATA, JSON.stringify(formDataObj));
-            }
+            // Save or remove data via shared helper
+            persistFormDataCache(formDataObj);
 
             currentViews[viewId] = viewId;
 
@@ -5078,6 +5082,7 @@ function Ktl($, appInfo) {
         //Also adds Change event handlers for dropdowns and calendars.   Eventually, support all object types.
         //After loading, re-validates numeric fields and highlights errors in pink.
         let viewLoadPromises = new Map();
+        let formDataVersion = 0;
 
         function parsePersistentFormStorage() {
             const storedData = ktl.storage.lsGetItem(PERSISTENT_FORM_DATA);
@@ -5115,12 +5120,13 @@ function Ktl($, appInfo) {
                 }
 
                 currentViews = {};
+                const versionToken = ++formDataVersion;
 
                 const targetViews = getTargetViews(viewId);
                 if (!targetViews.length) return resolve();
 
                 const loadPromises = targetViews.map(viewAttr =>
-                    ensureViewLoadPromise(viewAttr, parsedFormData, markViewLoaded)
+                    ensureViewLoadPromise(viewAttr, parsedFormData, markViewLoaded, versionToken)
                 );
 
                 Promise.all(loadPromises).then(() => {
@@ -5145,11 +5151,13 @@ function Ktl($, appInfo) {
                     .filter(Boolean);
             }
 
-            function ensureViewLoadPromise(viewAttr, parsedFormData, markLoaded) {
+            function ensureViewLoadPromise(viewAttr, parsedFormData, markLoaded, versionToken) {
                 if (!viewAttr) return Promise.resolve();
 
                 const existingLoad = viewLoadPromises.get(viewAttr.key);
-                if (existingLoad) return existingLoad;
+                if (existingLoad && existingLoad.version === versionToken) {
+                    return existingLoad.promise;
+                }
 
                 const loadPromise = loadDataForView(viewAttr, parsedFormData)
                     .then(() => {
@@ -5158,10 +5166,13 @@ function Ktl($, appInfo) {
                         }
                     })
                     .finally(() => {
-                        viewLoadPromises.delete(viewAttr.key);
+                        const cached = viewLoadPromises.get(viewAttr.key);
+                        if (cached && cached.promise === loadPromise) {
+                            viewLoadPromises.delete(viewAttr.key);
+                        }
                     });
 
-                viewLoadPromises.set(viewAttr.key, loadPromise);
+                viewLoadPromises.set(viewAttr.key, { promise: loadPromise, version: versionToken });
                 return loadPromise;
             }
         }
@@ -5191,7 +5202,9 @@ function Ktl($, appInfo) {
                 function finish() {
                     if (finished) return;
                     finished = true;
+                    teardownConnectionHydrationState(targetViewId);
                     HYDRATING_VIEWS.delete(targetViewId);
+                    flushPendingHydrationSaves(targetViewId);
                     clearTimeout(pfTimeout);
                     resolve();
                 }
@@ -5276,18 +5289,20 @@ function Ktl($, appInfo) {
                     } else {
                         ktl.log.clog('purple', 'Unsupported field type: ' + fieldId + ', ' + fieldType);
                     }
-
-                    if (!hasReloadLastValues) {
-                        delete storedViewData[fieldKey];
-                    }
                 }
 
-                if (!hasReloadLastValues) {
-                    delete parsedFormData[targetViewId];
-                }
+                Promise.resolve(waitForConnectionHydrationCompletion(targetViewId))
+                    .catch(error => {
+                        console.warn('Persistent Form - connection hydration wait failed', targetViewId, error);
+                    })
+                    .finally(() => {
+                        if (!hasReloadLastValues) {
+                            delete parsedFormData[targetViewId];
+                        }
 
-                persistFormDataCache(parsedFormData);
-                finish();
+                        persistFormDataCache(parsedFormData);
+                        finish();
+                    });
             });
         }
 
@@ -5415,8 +5430,22 @@ function Ktl($, appInfo) {
         function hydrateConnectionField({ fieldId, fieldValue, viewId, formDataObj }) {
             let normalizedValue = fieldValue;
             if (typeof normalizedValue === 'object' && formDataObj[viewId] && formDataObj[viewId][fieldId]) {
-                const [subField] = Object.keys(formDataObj[viewId][fieldId]);
-                normalizedValue = subField ? formDataObj[viewId][fieldId][subField] : '';
+                const fieldData = formDataObj[viewId][fieldId];
+                const subFields = Object.keys(fieldData);
+
+                if (subFields.length > 1) {
+                    console.warn('Persistent Form - multiple connection subfields detected', {
+                        viewId,
+                        fieldId,
+                        subFields,
+                    });
+                }
+
+                const aggregatedValues = subFields
+                    .map(subField => fieldData[subField])
+                    .filter(value => Boolean(value && String(value).trim().length));
+
+                normalizedValue = aggregatedValues.join(';');
             }
 
             if (!normalizedValue) return;
@@ -5438,7 +5467,15 @@ function Ktl($, appInfo) {
                     const options = JSON.parse(fieldValue);
                     Object.keys(options).forEach(key => {
                         const option = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttributeValue(key)}"]`);
-                        if (option && option.checked !== Boolean(options[key])) option.click();
+                        if (!option) return;
+
+                        const rawValue = options[key];
+                        const shouldBeChecked =
+                            typeof rawValue === 'boolean'
+                                ? rawValue
+                                : rawValue === 'true' || rawValue === 1 || rawValue === '1';
+
+                        if (option.checked !== shouldBeChecked) option.click();
                     });
                 } catch (error) {
                     console.warn('Persistent Form - invalid multiple choice data', fieldId, error);
@@ -5453,7 +5490,14 @@ function Ktl($, appInfo) {
         function hydrateBooleanField({ fieldId, fieldValue, viewId, field }) {
             if (field.attributes.format.input === 'checkbox') {
                 const checkbox = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input`);
-                if (checkbox && fieldValue === 'true' && !checkbox.checked) checkbox.click();
+                if (!checkbox) return;
+
+                const shouldBeChecked = normalizeBooleanValue(fieldValue);
+                if (shouldBeChecked === null) return;
+
+                if (checkbox.checked !== shouldBeChecked) {
+                    checkbox.click();
+                }
             } else if (field.attributes.format.input === 'radios') {
                 const radio = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttributeValue(fieldValue)}"]`);
                 radio && radio.click();
@@ -5544,6 +5588,9 @@ function Ktl($, appInfo) {
                     pending: new Map(),
                     handler: null,
                     retryTimer: null,
+                    retryDelayIndex: 0,
+                    completionPromise: null,
+                    resolveCompletion: null,
                 };
                 CONNECTION_HYDRATION_QUEUE.set(viewId, state);
             }
@@ -5551,6 +5598,8 @@ function Ktl($, appInfo) {
             state.pending.set(fieldId, {
                 fieldValue,
                 attempts: 0,
+                pendingVerification: false,
+                verificationTimer: null,
             });
 
             attachConnectionHydrationListener(viewId);
@@ -5569,10 +5618,12 @@ function Ktl($, appInfo) {
             let needsRetryTimer = false;
 
             state.pending.forEach((entry, fieldId) => {
+                if (entry.pendingVerification) return;
+
                 const success = applyConnectionFieldValue({ fieldId, fieldValue: entry.fieldValue, viewId });
                 if (success) {
-                    state.pending.delete(fieldId);
-                    return;
+                    entry.pendingVerification = true;
+                    scheduleConnectionHydrationVerification({ fieldId, viewId });
                 } else {
                     entry.attempts += 1;
                     if (entry.attempts >= MAX_CONNECTION_HYDRATE_RETRIES) {
@@ -5589,11 +5640,8 @@ function Ktl($, appInfo) {
                 return;
             }
 
-            if (needsRetryTimer && !state.retryTimer) {
-                state.retryTimer = setTimeout(() => {
-                    state.retryTimer = null;
-                    runPendingConnectionHydrations(viewId);
-                }, CONNECTION_HYDRATE_RETRY_DELAY);
+            if (needsRetryTimer) {
+                scheduleConnectionHydrationRetry(viewId);
             }
         }
 
@@ -5623,7 +5671,189 @@ function Ktl($, appInfo) {
                 clearTimeout(state.retryTimer);
             }
 
+            state.pending.forEach(entry => {
+                if (entry.verificationTimer) {
+                    clearTimeout(entry.verificationTimer);
+                }
+            });
+
+            state.retryDelayIndex = 0;
+
+            if (state.resolveCompletion) {
+                state.resolveCompletion();
+            }
+
             CONNECTION_HYDRATION_QUEUE.delete(viewId);
+        }
+
+        function scheduleConnectionHydrationRetry(viewId) {
+            const state = CONNECTION_HYDRATION_QUEUE.get(viewId);
+            if (!state || state.retryTimer) return;
+
+            const delay = Math.min(
+                CONNECTION_HYDRATE_RETRY_DELAY_MIN * Math.pow(2, state.retryDelayIndex),
+                CONNECTION_HYDRATE_RETRY_DELAY_MAX
+            );
+
+            state.retryDelayIndex = Math.min(state.retryDelayIndex + 1, 10);
+
+            state.retryTimer = setTimeout(() => {
+                state.retryTimer = null;
+                runPendingConnectionHydrations(viewId);
+            }, delay);
+        }
+
+        function scheduleConnectionHydrationVerification({ fieldId, viewId }) {
+            const state = CONNECTION_HYDRATION_QUEUE.get(viewId);
+            if (!state) return;
+
+            const entry = state.pending.get(fieldId);
+            if (!entry) return;
+
+            entry.verificationTimer = setTimeout(() => {
+                entry.pendingVerification = false;
+                entry.verificationTimer = null;
+
+                const verified = verifyConnectionHydration({ fieldId, fieldValue: entry.fieldValue, viewId });
+                if (verified) {
+                    state.pending.delete(fieldId);
+                    resetConnectionHydrationBackoff(state);
+                    if (state.pending.size === 0) {
+                        teardownConnectionHydrationState(viewId);
+                    }
+                } else {
+                    entry.attempts += 1;
+                    if (entry.attempts >= MAX_CONNECTION_HYDRATE_RETRIES) {
+                        console.warn('Persistent Form - connection hydration verification failed', viewId, fieldId);
+                        state.pending.delete(fieldId);
+                        if (state.pending.size === 0) {
+                            teardownConnectionHydrationState(viewId);
+                        }
+                    } else {
+                        scheduleConnectionHydrationRetry(viewId);
+                    }
+                }
+            }, CONNECTION_HYDRATE_VERIFY_DELAY);
+        }
+
+        function verifyConnectionHydration({ fieldId, fieldValue, viewId }) {
+            const selectSelector = `#${viewId}-${fieldId}`;
+            const select = $(selectSelector);
+            if (select.length && select.hasClass('chzn-select')) {
+                const expectedIds = parseConnectionOptionIds(fieldValue);
+                const appliedValues = select.val();
+                const appliedArray = Array.isArray(appliedValues)
+                    ? appliedValues.filter(Boolean)
+                    : (appliedValues ? [appliedValues] : []);
+                const appliedSet = new Set(appliedArray);
+                return expectedIds.every(id => appliedSet.has(id));
+            }
+
+            const radioContainer = document.querySelector(`#${viewId} #connection-picker-radio-${fieldId}`);
+            if (radioContainer) {
+                const radio = radioContainer.querySelector(`input[value="${escapeForAttributeValue(fieldValue)}"]`);
+                return Boolean(radio && radio.checked);
+            }
+
+            const checkboxContainer = document.querySelector(`#${viewId} #connection-picker-checkbox-${fieldId}`);
+            if (checkboxContainer) {
+                const expectedValues = ktl.core.splitAndTrimToArray(fieldValue, ',');
+                return expectedValues.every(value => {
+                    const checkbox = checkboxContainer.querySelector(`input[value="${escapeForAttributeValue(value)}"]`);
+                    return Boolean(checkbox && checkbox.checked);
+                });
+            }
+
+            return false;
+        }
+
+        function parseConnectionOptionIds(fieldValue = '') {
+            const optionStrings = ktl.core.splitAndTrimToArray(fieldValue, ';');
+            return optionStrings
+                .map(record => {
+                    const parts = record.split(':');
+                    return parts.length > 1 ? parts[1] : parts[0];
+                })
+                .filter(id => id && ktl.core.hasRecordIdFormat(id));
+        }
+
+        function normalizeBooleanValue(value) {
+            if (typeof value === 'boolean') {
+                return value;
+            }
+
+            if (typeof value === 'string') {
+                const lower = value.toLowerCase().trim();
+                if (lower === 'true') return true;
+                if (lower === 'false') return false;
+            }
+
+            if (value === 1 || value === '1') return true;
+            if (value === 0 || value === '0') return false;
+
+            return null;
+        }
+
+        function waitForConnectionHydrationCompletion(viewId) {
+            const state = CONNECTION_HYDRATION_QUEUE.get(viewId);
+            if (!state) return Promise.resolve();
+
+            if (!state.completionPromise) {
+                state.completionPromise = new Promise(resolve => {
+                    state.resolveCompletion = resolve;
+                });
+            }
+
+            return state.completionPromise;
+        }
+
+        function clearAllConnectionHydrationStates() {
+            CONNECTION_HYDRATION_QUEUE.forEach((_, viewId) => {
+                teardownConnectionHydrationState(viewId);
+            });
+        }
+
+        function resetConnectionHydrationBackoff(state) {
+            if (state) {
+                state.retryDelayIndex = 0;
+            }
+        }
+
+        function queuePendingHydrationSave({ data, viewId, fieldId, subField }) {
+            if (!viewId || !fieldId) return;
+
+            const queuedValue = clonePersistedValue(data);
+            const existingQueue = PENDING_HYDRATION_SAVES.get(viewId) || [];
+
+            existingQueue.push({
+                data: queuedValue,
+                fieldId,
+                subField: subField || '',
+            });
+
+            PENDING_HYDRATION_SAVES.set(viewId, existingQueue);
+        }
+
+        function flushPendingHydrationSaves(viewId) {
+            if (!viewId) return;
+            const queue = PENDING_HYDRATION_SAVES.get(viewId);
+            if (!queue || !queue.length) return;
+
+            PENDING_HYDRATION_SAVES.delete(viewId);
+
+            queue.forEach(entry => {
+                saveFormData(entry.data, viewId, entry.fieldId, entry.subField);
+            });
+        }
+
+        function clonePersistedValue(value) {
+            if (value === null || typeof value !== 'object') return value;
+            try {
+                return JSON.parse(JSON.stringify(value));
+            } catch (error) {
+                console.warn('Persistent Form - unable to clone pending save value', error);
+                return value;
+            }
         }
 
         function escapeForCssIdentifier(value = '') {
@@ -5648,6 +5878,7 @@ function Ktl($, appInfo) {
         function eraseFormData(viewId) {
             // Handle single view case
             if (viewId) {
+                PENDING_HYDRATION_SAVES.delete(viewId);
                 const formData = ktl.storage.lsGetItem(PERSISTENT_FORM_DATA);
                 let expiryDate = null;
                 if (!formData) return;

--- a/KTL.js
+++ b/KTL.js
@@ -3368,7 +3368,7 @@ function Ktl($, appInfo) {
             const chosenUpdateTimeouts = {};
             $(`#${viewId} .chzn-select`).on('change', function (e) {
                 try {
-                    if (!$(`.ktlPersistenFormLoadedScene`).length) return;
+                    if (!$(`.ktlPersistentFormLoadedScene`).length) return;
                     if (!e.target.id || !e.target.selectedOptions) return;
 
                     const key = e.target.id;
@@ -4755,8 +4755,9 @@ function Ktl($, appInfo) {
         const PERSISTENT_FORM_DATA = 'persistentForm';
         const MAX_CONNECTION_HYDRATE_RETRIES = 6;
         const CONNECTION_HYDRATE_RETRY_DELAY = 500;
-        const CONNECTION_EVENT_WAIT_TIMEOUT = 5000;
-        const connectionHydrationQueue = new Map();
+        const FIELD_DEFINITION_CACHE = new Map();
+        const CONNECTION_HYDRATION_QUEUE = new Map();
+        const HYDRATING_VIEWS = new Set();
         //To see all data types:  console.log(Knack.config);
 
         //Add fields and scenes to exclude from persistence in these arrays.
@@ -4784,15 +4785,13 @@ function Ktl($, appInfo) {
             ktl.fields.sceneConvertNumToTel().then(() => {
                 if (!ktl.core.getCfg().enabled.persistentForm || scenesToExclude.includes(scene.key)) {
                     //Allow other features that depend on this event to run, even if PF is not enabled.
-                    $('.kn-scene').addClass('ktlPersistenFormLoadedScene');
-                    $(document).trigger('KTL.persistentForm.completed.scene', [scene]);
+                    markSceneLoaded(scene);
                 } else {
                     loadFormData()
                         .then(() => {
                             setTimeout(() => {
                                 ktl.fields.enforceNumeric();
-                                $('.kn-scene').addClass('ktlPersistenFormLoadedScene');
-                                $(document).trigger('KTL.persistentForm.completed.scene', [scene]);
+                                markSceneLoaded(scene);
                             }, 1000);
                         })
                 }
@@ -4821,8 +4820,7 @@ function Ktl($, appInfo) {
 
             if (!ktl.core.getCfg().enabled.persistentForm || (view.scene && scenesToExclude.includes(view.scene.key))) {
                 //Allow other features that depend on this event to run, even if PF is not enabled.
-                $(`#${viewId}`).addClass('ktlPersistenFormLoadedView');
-                $(document).trigger(`KTL.persistentForm.completed.view.${viewId}`, viewId);
+                markViewLoaded(viewId);
                 return;
             }
 
@@ -4945,6 +4943,7 @@ function Ktl($, appInfo) {
         function saveFormData(data, viewId, fieldId, subField) {
             // Guard clauses
             if (!pfIsInitialized || !fieldId || !viewId || !viewId.startsWith('view_')) return;
+            if (HYDRATING_VIEWS.has(viewId)) return;
 
             const fieldType = ktl.fields.getFieldType(fieldId);
             if (!fieldType || fieldType === 'password') return;
@@ -5097,13 +5096,8 @@ function Ktl($, appInfo) {
                 ktl.storage.lsSetItem(PERSISTENT_FORM_DATA, JSON.stringify(data));
             }
         }
-        function loadFormData(viewId) {
-            function markViewLoaded(targetViewId) {
-                if (!targetViewId) return;
-                $(`#${targetViewId}`).addClass('ktlPersistenFormLoadedView');
-                $(document).trigger(`KTL.persistentForm.completed.view.${targetViewId}`, targetViewId);
-            }
 
+        function loadFormData(viewId) {
             return new Promise((resolve) => {
                 const parsedFormData = parsePersistentFormStorage();
 
@@ -5112,8 +5106,7 @@ function Ktl($, appInfo) {
                     if (viewId) {
                         markViewLoaded(viewId);
                     } else {
-                        $('.kn-scene').addClass('ktlPersistenFormLoadedScene');
-                        $(document).trigger('KTL.persistentForm.completed.scene', [Knack.router.scene_view.model]);
+                        markSceneLoaded();
                     }
                     return resolve();
                 }
@@ -5123,8 +5116,16 @@ function Ktl($, appInfo) {
                 const targetViews = getTargetViews(viewId);
                 if (!targetViews.length) return resolve();
 
-                const loadPromises = targetViews.map(viewAttr => ensureViewLoadPromise(viewAttr, parsedFormData, markViewLoaded));
-                Promise.all(loadPromises).then(() => resolve());
+                const loadPromises = targetViews.map(viewAttr =>
+                    ensureViewLoadPromise(viewAttr, parsedFormData, markViewLoaded)
+                );
+
+                Promise.all(loadPromises).then(() => {
+                    if (!viewId) {
+                        markSceneLoaded();
+                    }
+                    resolve();
+                });
             });
 
             function getTargetViews(targetViewId) {
@@ -5149,7 +5150,7 @@ function Ktl($, appInfo) {
 
                 const loadPromise = loadDataForView(viewAttr, parsedFormData)
                     .then(() => {
-                        if (viewAttr.type === 'form' && (viewAttr.action === 'insert' || viewAttr.action === 'create')) {
+                        if (isInsertCreateForm(viewAttr)) {
                             markLoaded(viewAttr.key);
                         }
                     })
@@ -5160,143 +5161,248 @@ function Ktl($, appInfo) {
                 viewLoadPromises.set(viewAttr.key, loadPromise);
                 return loadPromise;
             }
+        }
 
-            function loadDataForView(viewAttr, parsedFormData) {
-                return new Promise((resolve) => {
-                    if (!viewAttr || viewAttr.type !== 'form') return resolve();
-                    if (viewAttr.action !== 'insert' && viewAttr.action !== 'create') return resolve();
+        function loadDataForView(viewAttr, parsedFormData) {
+            // Fast exits: no promise allocation if nothing to do
+            if (!isInsertCreateForm(viewAttr)) {
+                return Promise.resolve();
+            }
 
-                    const storedViewData = parsedFormData[viewAttr.key];
-                    if (!storedViewData) return resolve();
+            const targetViewId = viewAttr.key;
+            const storedViewData = parsedFormData[targetViewId];
 
-                    const pfTimeout = setTimeout(() => {
-                        console.log('loadDataForView timeout expired.', viewAttr.key);
-                        finish();
-                    }, 20000);
+            if (!storedViewData) {
+                return Promise.resolve();
+            }
 
-                    let finished = false;
-                    const finish = () => {
-                        if (finished) return;
-                        finished = true;
-                        clearTimeout(pfTimeout);
-                        resolve();
-                    };
+            HYDRATING_VIEWS.add(targetViewId);
 
-                    currentViews[viewAttr.key] = viewAttr.key;
+            return new Promise((resolve) => {
+                const pfTimeout = setTimeout(() => {
+                    console.log('loadDataForView timeout expired.', targetViewId);
+                    finish();
+                }, 20000);
 
-                    const hasReloadLastValues = Boolean(ktlKeywords[viewAttr.key] && ktlKeywords[viewAttr.key]._rlv);
+                let finished = false;
+                function finish() {
+                    if (finished) return;
+                    finished = true;
+                    HYDRATING_VIEWS.delete(targetViewId);
+                    clearTimeout(pfTimeout);
+                    resolve();
+                }
 
-                    if (storedViewData.expiryDate && new Date(storedViewData.expiryDate) < new Date()) {
-                        delete parsedFormData[viewAttr.key];
+                currentViews[targetViewId] = targetViewId;
+
+                const hasReloadLastValues = Boolean(
+                    ktlKeywords[targetViewId] &&
+                    ktlKeywords[targetViewId]._rlv
+                );
+
+                if (storedViewData.expiryDate) {
+                    const nowTs = Date.now();
+                    const expiryTime = Date.parse(storedViewData.expiryDate);
+                    if (!Number.isNaN(expiryTime) && expiryTime < nowTs) {
+                        delete parsedFormData[targetViewId];
                         persistFormDataCache(parsedFormData);
                         return finish();
                     }
+                }
 
-                    const targetViewId = viewAttr.key;
-                    const keys = Object.keys(storedViewData).filter(key => key !== 'expiryDate');
-                    for (const fieldKey of keys) {
-                        const fieldIdMatch = fieldKey.match(/field_\d+/);
-                        const fieldId = fieldIdMatch ? fieldIdMatch[0] : null;
+                const keys = Object.keys(storedViewData).filter(key => key !== 'expiryDate');
 
-                        if (fieldsToExclude.includes(fieldId)) {
-                            ktl.log.clog('purple', 'Skipped field for PF: ' + fieldId);
-                            continue;
-                        }
+                for (const fieldKey of keys) {
+                    const fieldIdMatch = fieldKey.match(/field_\d+/);
+                    const fieldId = fieldIdMatch ? fieldIdMatch[0] : null;
 
-                        const field = fieldId ? Knack.objects.getField(fieldId) : null;
-                        if (!field) continue;
+                    if (fieldId && fieldsToExclude.includes(fieldId)) {
+                        ktl.log.clog('purple', 'Skipped field for PF: ' + fieldId);
+                        continue;
+                    }
 
-                        const fieldType = field.attributes.type;
-                        let fieldValue = storedViewData[fieldKey] || storedViewData[fieldId];
+                    const field = getFieldDefinition(fieldId);
+                    if (!field) continue;
 
-                        if (fieldType === 'rich_text') {
-                            hydrateRichTextField({ fieldId, fieldValue, viewId: targetViewId });
-                        } else if (TEXT_DATA_TYPES.includes(fieldType)) {
-                            hydrateTextField({ fieldId, fieldKey, fieldValue, viewId: targetViewId, field, formDataObj: parsedFormData, preserveFieldData: hasReloadLastValues });
-                        } else if (fieldType === 'connection') {
-                            hydrateConnectionField({ fieldId, fieldValue, viewId: targetViewId, formDataObj: parsedFormData });
-                        } else if (fieldType === 'multiple_choice') {
-                            hydrateMultipleChoiceField({ fieldId, fieldValue, viewId: targetViewId, field });
-                        } else if (fieldType === 'boolean') {
-                            hydrateBooleanField({ fieldId, fieldValue, viewId: targetViewId, field });
-                        } else if (['password', 'file', 'image'].includes(fieldType)) {
-                            //Ignore.
-                        } else {
-                            ktl.log.clog('purple', 'Unsupported field type: ' + fieldId + ', ' + fieldType);
-                        }
+                    const fieldType = field.attributes.type;
 
-                        if (!hasReloadLastValues) {
-                            delete storedViewData[fieldKey];
-                        }
+                    let fieldValue = storedViewData[fieldKey];
+                    if (typeof fieldValue === 'undefined' && fieldId) {
+                        fieldValue = storedViewData[fieldId];
+                    }
+
+                    if (typeof fieldValue === 'undefined' || fieldValue === null) {
+                        continue;
+                    }
+
+                    if (fieldType === 'rich_text') {
+                        hydrateRichTextField({ fieldId, fieldValue, viewId: targetViewId });
+                    } else if (TEXT_DATA_TYPES.includes(fieldType)) {
+                        hydrateTextField({
+                            fieldId,
+                            fieldKey,
+                            fieldValue,
+                            viewId: targetViewId,
+                            field,
+                            formDataObj: parsedFormData,
+                            preserveFieldData: hasReloadLastValues
+                        });
+                    } else if (fieldType === 'connection') {
+                        hydrateConnectionField({
+                            fieldId,
+                            fieldValue,
+                            viewId: targetViewId,
+                            formDataObj: parsedFormData
+                        });
+                    } else if (fieldType === 'multiple_choice') {
+                        hydrateMultipleChoiceField({
+                            fieldId,
+                            fieldValue,
+                            viewId: targetViewId,
+                            field
+                        });
+                    } else if (fieldType === 'boolean') {
+                        hydrateBooleanField({
+                            fieldId,
+                            fieldValue,
+                            viewId: targetViewId,
+                            field
+                        });
+                    } else if (['password', 'file', 'image'].includes(fieldType)) {
+                        // Ignore.
+                    } else {
+                        ktl.log.clog('purple', 'Unsupported field type: ' + fieldId + ', ' + fieldType);
                     }
 
                     if (!hasReloadLastValues) {
-                        delete parsedFormData[targetViewId];
+                        delete storedViewData[fieldKey];
                     }
+                }
 
-                    persistFormDataCache(parsedFormData);
-                    finish();
-                });
+                if (!hasReloadLastValues) {
+                    delete parsedFormData[targetViewId];
+                }
+
+                persistFormDataCache(parsedFormData);
+                finish();
+            });
+        }
+
+        function getFieldDefinition(fieldId) {
+            if (!fieldId) return null;
+
+            if (FIELD_DEFINITION_CACHE.has(fieldId)) {
+                return FIELD_DEFINITION_CACHE.get(fieldId);
+            }
+
+            const field = Knack.objects.getField(fieldId);
+            if (field) {
+                FIELD_DEFINITION_CACHE.set(fieldId, field);
+            }
+
+            return field;
+        }
+
+        function isInsertCreateForm(viewAttr) {
+            return Boolean(
+                viewAttr &&
+                viewAttr.type === 'form' &&
+                (viewAttr.action === 'insert' || viewAttr.action === 'create')
+            );
+        }
+
+        function markViewLoaded(targetViewId) {
+            if (!targetViewId) return;
+            $(`#${targetViewId}`).addClass('ktlPersistentFormLoadedView');
+            $(document).trigger(`KTL.persistentForm.completed.view.${targetViewId}`, targetViewId);
+        }
+
+        function markSceneLoaded(sceneModel = Knack.router.scene_view && Knack.router.scene_view.model) {
+            $('.kn-scene').addClass('ktlPersistentFormLoadedScene');
+            if (sceneModel) {
+                $(document).trigger('KTL.persistentForm.completed.scene', [sceneModel]);
             }
         }
 
         function hydrateRichTextField({ fieldId, fieldValue, viewId }) {
             const editor = $(`#${viewId} #${fieldId}`);
             if (!editor.length) return;
-            editor.data('redactor').code.set(fieldValue);
+            const redactor = editor.data('redactor');
+            if (redactor && redactor.code) {
+                redactor.code.set(fieldValue);
+            }
         }
 
-        function hydrateTextField({ fieldId, fieldKey, fieldValue, viewId, field, formDataObj, preserveFieldData = false }) {
+        function hydrateTextField({
+            fieldId,
+            fieldKey,
+            fieldValue,
+            viewId,
+            field,
+            formDataObj,
+            preserveFieldData = false
+        }) {
             const viewElement = document.getElementById(viewId);
             if (!viewElement) return;
+
             const fieldContainer = viewElement.querySelector(`[data-input-id="${fieldId}"]`);
             if (!fieldContainer) return;
 
-            const setFieldText = (subField = '') => {
+            const setFieldText = (value, subField = '') => {
                 if (subField) {
                     const selectElement = fieldContainer.querySelector(`select[name="${subField}"]`);
                     if (selectElement) {
-                        selectElement.value = fieldValue;
+                        selectElement.value = value;
                         return;
                     }
                 }
 
                 let element;
+
                 if (field.attributes.type === 'date_time' || field.attributes.type === 'timer') {
-                    element = document.querySelector(`#${viewId}-${fieldKey}`);
+                    element = document.getElementById(`${viewId}-${fieldKey}`);
                 } else {
                     if (subField) {
-                        const escapedSubField = escapeForAttribute(subField);
-                        element = fieldContainer.querySelector(`#${escapedSubField}.input`) ||
+                        const escapedSubField = escapeForCssIdentifier(subField);
+                        element =
+                            fieldContainer.querySelector(`#${escapedSubField}.input`) ||
                             fieldContainer.querySelector(`#${escapedSubField}`);
                     }
 
                     if (!element) {
-                        element = fieldContainer.querySelector('input') ||
+                        element =
+                            fieldContainer.querySelector('input') ||
                             fieldContainer.querySelector('.kn-textarea');
                     }
                 }
 
                 if (element) {
                     if ('value' in element) {
-                        element.value = fieldValue;
+                        element.value = value;
                     } else {
-                        element.textContent = fieldValue;
+                        element.textContent = value;
                     }
                 }
             };
 
-            if (typeof fieldValue === 'object') {
-                const subFields = Object.keys(formDataObj[viewId][fieldId] || {});
+            if (typeof fieldValue === 'object' && fieldValue !== null) {
+                const viewData = formDataObj[viewId];
+                const fieldData = viewData && viewData[fieldId];
+
+                if (!fieldData) {
+                    return;
+                }
+
+                const subFields = Object.keys(fieldData);
                 subFields.forEach(subField => {
-                    fieldValue = formDataObj[viewId][fieldId][subField];
-                    setFieldText(subField);
+                    const currentValue = fieldData[subField];
+                    setFieldText(currentValue, subField);
                     if (!preserveFieldData) {
-                        delete formDataObj[viewId][fieldId][subField];
+                        delete fieldData[subField];
                     }
                 });
             } else {
-                setFieldText();
+                setFieldText(fieldValue);
                 if (!preserveFieldData && formDataObj[viewId]) {
                     delete formDataObj[viewId][fieldKey];
                 }
@@ -5304,14 +5410,15 @@ function Ktl($, appInfo) {
         }
 
         function hydrateConnectionField({ fieldId, fieldValue, viewId, formDataObj }) {
-            if (typeof fieldValue === 'object' && formDataObj[viewId] && formDataObj[viewId][fieldId]) {
+            let normalizedValue = fieldValue;
+            if (typeof normalizedValue === 'object' && formDataObj[viewId] && formDataObj[viewId][fieldId]) {
                 const [subField] = Object.keys(formDataObj[viewId][fieldId]);
-                fieldValue = subField ? formDataObj[viewId][fieldId][subField] : '';
+                normalizedValue = subField ? formDataObj[viewId][fieldId][subField] : '';
             }
 
-            if (!fieldValue) return;
+            if (!normalizedValue) return;
 
-            enqueueConnectionHydration({ fieldId, fieldValue, viewId });
+            enqueueConnectionHydration({ fieldId, fieldValue: normalizedValue, viewId });
         }
 
         function hydrateMultipleChoiceField({ fieldId, fieldValue, viewId, field }) {
@@ -5321,14 +5428,18 @@ function Ktl($, appInfo) {
                     if (element) element.value = fieldValue[subField];
                 });
             } else if (field.attributes.format.type === 'radios') {
-                const radio = document.querySelector(`#${viewId} #kn-input-${fieldId} [value="${escapeForAttribute(fieldValue)}"]`);
+                const radio = document.querySelector(`#${viewId} #kn-input-${fieldId} [value="${escapeForAttributeValue(fieldValue)}"]`);
                 radio && radio.click();
             } else if (field.attributes.format.type === 'checkboxes') {
-                const options = JSON.parse(fieldValue);
-                Object.keys(options).forEach(key => {
-                    const option = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttribute(key)}"]`);
-                    if (option && option.checked !== Boolean(options[key])) option.click();
-                });
+                try {
+                    const options = JSON.parse(fieldValue);
+                    Object.keys(options).forEach(key => {
+                        const option = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttributeValue(key)}"]`);
+                        if (option && option.checked !== Boolean(options[key])) option.click();
+                    });
+                } catch (error) {
+                    console.warn('Persistent Form - invalid multiple choice data', fieldId, error);
+                }
             } else {
                 const values = $(`#${viewId}-${fieldId}`).val() || [];
                 const choices = fieldValue.split(';').map(choice => choice.split(':')[0])
@@ -5341,7 +5452,7 @@ function Ktl($, appInfo) {
                 const checkbox = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input`);
                 if (checkbox && fieldValue === 'true' && !checkbox.checked) checkbox.click();
             } else if (field.attributes.format.input === 'radios') {
-                const radio = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttribute(fieldValue)}"]`);
+                const radio = document.querySelector(`#${viewId} [data-input-id="${fieldId}"] input[value="${escapeForAttributeValue(fieldValue)}"]`);
                 radio && radio.click();
             } else {
                 const selectElement = document.querySelector(`#${viewId} select#${fieldId}.select`);
@@ -5391,7 +5502,7 @@ function Ktl($, appInfo) {
 
             const radioContainer = document.querySelector(`#${viewId} #connection-picker-radio-${fieldId}`);
             if (radioContainer) {
-                const radio = radioContainer.querySelector(`input[value="${escapeForAttribute(fieldValue)}"]`);
+                const radio = radioContainer.querySelector(`input[value="${escapeForAttributeValue(fieldValue)}"]`);
                 if (radio) {
                     if (!radio.checked) radio.click();
                     return radio.checked;
@@ -5401,12 +5512,12 @@ function Ktl($, appInfo) {
 
             const checkboxContainer = document.querySelector(`#${viewId} #connection-picker-checkbox-${fieldId}`);
             if (checkboxContainer) {
-                const values = fieldValue.split(',').map(value => value.trim()).filter(Boolean);
+                const values = ktl.core.splitAndTrimToArray(fieldValue, ',');
                 if (!values.length) return true;
 
                 let success = true;
                 values.forEach(value => {
-                    const checkbox = checkboxContainer.querySelector(`input[value="${escapeForAttribute(value)}"]`);
+                    const checkbox = checkboxContainer.querySelector(`input[value="${escapeForAttributeValue(value)}"]`);
                     if (checkbox) {
                         if (!checkbox.checked) checkbox.click();
                         success = success && checkbox.checked;
@@ -5418,42 +5529,33 @@ function Ktl($, appInfo) {
                 return success;
             }
 
-            const nativeSelect = document.querySelector(selectSelector);
-            if (nativeSelect) {
-                nativeSelect.value = fieldValue;
-                nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
-                return nativeSelect.value === fieldValue;
-            }
-
             return false;
         }
 
         function enqueueConnectionHydration({ fieldId, fieldValue, viewId }) {
             if (!fieldValue || !viewId) return;
 
-            let state = connectionHydrationQueue.get(viewId);
+            let state = CONNECTION_HYDRATION_QUEUE.get(viewId);
             if (!state) {
                 state = {
                     pending: new Map(),
                     handler: null,
                     retryTimer: null,
                 };
-                connectionHydrationQueue.set(viewId, state);
+                CONNECTION_HYDRATION_QUEUE.set(viewId, state);
             }
 
             state.pending.set(fieldId, {
                 fieldValue,
                 attempts: 0,
-                awaitingEvent: false,
-                eventDeadline: 0,
             });
 
             attachConnectionHydrationListener(viewId);
             runPendingConnectionHydrations(viewId);
         }
 
-        function runPendingConnectionHydrations(viewId, triggeredByEvent = false) {
-            const state = connectionHydrationQueue.get(viewId);
+        function runPendingConnectionHydrations(viewId) {
+            const state = CONNECTION_HYDRATION_QUEUE.get(viewId);
             if (!state) return;
 
             if (state.retryTimer) {
@@ -5464,25 +5566,10 @@ function Ktl($, appInfo) {
             let needsRetryTimer = false;
 
             state.pending.forEach((entry, fieldId) => {
-                if (entry.awaitingEvent && !triggeredByEvent) {
-                    if (Date.now() >= entry.eventDeadline) {
-                        entry.awaitingEvent = false;
-                    } else {
-                        needsRetryTimer = true;
-                        return;
-                    }
-                }
-
                 const success = applyConnectionFieldValue({ fieldId, fieldValue: entry.fieldValue, viewId });
                 if (success) {
-                    if (triggeredByEvent) {
-                        state.pending.delete(fieldId);
-                    } else {
-                        entry.awaitingEvent = true;
-                        entry.eventDeadline = Date.now() + CONNECTION_EVENT_WAIT_TIMEOUT;
-                        entry.attempts = 0;
-                        needsRetryTimer = true;
-                    }
+                    state.pending.delete(fieldId);
+                    return;
                 } else {
                     entry.attempts += 1;
                     if (entry.attempts >= MAX_CONNECTION_HYDRATE_RETRIES) {
@@ -5508,20 +5595,21 @@ function Ktl($, appInfo) {
         }
 
         function attachConnectionHydrationListener(viewId) {
-            const state = connectionHydrationQueue.get(viewId);
+            const state = CONNECTION_HYDRATION_QUEUE.get(viewId);
             if (!state || state.handler) return;
 
             const eventName = `knack-connections-load.${viewId}`;
             const handler = () => {
-                setTimeout(() => runPendingConnectionHydrations(viewId, true), 0);
+                setTimeout(() => runPendingConnectionHydrations(viewId), 0);
             };
 
             state.handler = handler;
             $(document).on(eventName, handler);
         }
 
+
         function teardownConnectionHydrationState(viewId) {
-            const state = connectionHydrationQueue.get(viewId);
+            const state = CONNECTION_HYDRATION_QUEUE.get(viewId);
             if (!state) return;
 
             if (state.handler) {
@@ -5532,14 +5620,22 @@ function Ktl($, appInfo) {
                 clearTimeout(state.retryTimer);
             }
 
-            connectionHydrationQueue.delete(viewId);
+            CONNECTION_HYDRATION_QUEUE.delete(viewId);
         }
 
-        function escapeForAttribute(value = '') {
+        function escapeForCssIdentifier(value = '') {
             if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
                 return CSS.escape(value);
             }
-            return value.replace(/["\\]/g, '\\$&');
+            const strValue = String(value);
+            return strValue
+                .replace(/^[0-9]/, match => `\\${match}`)
+                .replace(/[^a-zA-Z0-9_-]/g, match => `\\${match}`);
+        }
+
+        function escapeForAttributeValue(value = '') {
+            const strValue = String(value);
+            return strValue.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         }
 
         //Remove all saved data for this view after a submit
@@ -13617,7 +13713,7 @@ function Ktl($, appInfo) {
             if (!(viewId && keywords && keywords[kw])) return;
 
             try {
-                await ktl.core.waitSelector(`#${viewId}.ktlPersistenFormLoadedView`, 20000);
+                await ktl.core.waitSelector(`#${viewId}.ktlPersistentFormLoadedView`, 20000);
 
                 const kwList = ktl.core.getKeywordsByType(viewId, kw);
                 kwList.forEach(kwInstance => { execKw(kwInstance); })
@@ -14249,7 +14345,7 @@ function Ktl($, appInfo) {
 
                             if (viewType === 'form') {
                                 hide();
-                                ktl.core.waitSelector('.ktlPersistenFormLoadedScene', 5000)
+                                ktl.core.waitSelector('.ktlPersistentFormLoadedScene', 5000)
                                     .then(() => {
                                         ktl.views.hideUnhideValidateKtlCond(keyword.options, hide, unhide);
                                     })

--- a/KTL.js
+++ b/KTL.js
@@ -4796,6 +4796,11 @@ function Ktl($, appInfo) {
         const CONNECTION_HYDRATION_QUEUE = new Map();
         const HYDRATING_VIEWS = new Set();
         const PENDING_HYDRATION_SAVES = new Map();
+
+        const DATE_TIME_FIELD_SUFFIXES = [
+            '-time', '-time-to', '-to', '-date-from',
+            '-time-from', '-date-to', ''
+        ];
         //To see all data types:  console.log(Knack.config);
 
         //Add fields and scenes to exclude from persistence in these arrays.
@@ -4893,6 +4898,24 @@ function Ktl($, appInfo) {
 
             if ((event.type === 'focusout' && event.relatedTarget) || event.type === 'input')
                 debouncedFormContentHasChanged(event.target);
+        });
+
+        // Capture rating widget changes so they persist.
+        $(document).on('rated reset', '.rateit', function (event, value) {
+            if (!pfIsInitialized) return;
+
+            const view = this.closest('.kn-form.kn-view');
+            if (!view) return;
+
+            const viewId = view.id;
+            const knInput = this.closest('.kn-input');
+            if (!knInput) return;
+
+            const fieldId = knInput.getAttribute('data-input-id');
+            if (!fieldId) return;
+
+            const ratingValue = (typeof value === 'number') ? value : $(this).rateit('value');
+            saveFormData(ratingValue, viewId, fieldId, '');
         });
 
         $(document).on('click', function (e) {
@@ -5058,11 +5081,7 @@ function Ktl($, appInfo) {
                     delete formDataObj[viewId][fieldId];
                 } else if (fieldType === 'date_time' || fieldType === 'timer') {
                     const fieldRootSelector = `#${viewId}-${fieldId}`;
-                    const dateTimeFieldsSuffixes = [
-                        '-time', '-time-to', '-to', '-date-from',
-                        '-time-from', '-date-to', ''
-                    ];
-                    dateTimeFieldsSuffixes.forEach((fieldSuffix) => {
+                    DATE_TIME_FIELD_SUFFIXES.forEach((fieldSuffix) => {
                         const element = $(`${fieldRootSelector}${fieldSuffix}`);
                         if (element.length) {
                             formDataObj[viewId][`${fieldId}${fieldSuffix}`] = element.val();
@@ -5129,6 +5148,12 @@ function Ktl($, appInfo) {
             }
         }
 
+        function isStoredViewExpired(storedViewData) {
+            if (!storedViewData || !storedViewData.expiryDate) return false;
+            const expiryTime = Date.parse(storedViewData.expiryDate);
+            return !Number.isNaN(expiryTime) && expiryTime < Date.now();
+        }
+
         function persistFormDataCache(data) {
             if (!data || $.isEmptyObject(data)) {
                 ktl.storage.lsRemoveItem(PERSISTENT_FORM_DATA);
@@ -5141,20 +5166,12 @@ function Ktl($, appInfo) {
             return new Promise((resolve) => {
                 const parsedFormData = parsePersistentFormStorage();
 
-                if (!parsedFormData || $.isEmptyObject(parsedFormData)) {
-                    persistFormDataCache(null);
-                    if (viewId) {
-                        markViewLoaded(viewId);
-                    } else {
-                        markSceneLoaded();
-                    }
-                    return resolve();
-                }
+                if (handleEmptyStorage(parsedFormData, viewId)) return resolve();
 
                 currentViews = {};
                 const versionToken = ++formDataVersion;
 
-                const targetViews = getTargetViews(viewId);
+                const targetViews = resolveTargetViews(viewId);
                 if (!targetViews.length) return resolve();
 
                 const loadPromises = targetViews.map(viewAttr =>
@@ -5168,45 +5185,55 @@ function Ktl($, appInfo) {
                     resolve();
                 });
             });
+        }
 
-            function getTargetViews(targetViewId) {
-                const sceneView = Knack.router.scene_view;
-                if (!sceneView || !sceneView.model || !sceneView.model.views) return [];
+        function handleEmptyStorage(parsedFormData, viewId) {
+            if (parsedFormData && !$.isEmptyObject(parsedFormData)) return false;
 
-                if (targetViewId) {
-                    const viewModel = sceneView.model.views._byId[targetViewId];
-                    return (viewModel && viewModel.attributes) ? [viewModel.attributes] : [];
-                }
+            persistFormDataCache(null);
+            if (viewId) {
+                markViewLoaded(viewId);
+            } else {
+                markSceneLoaded();
+            }
+            return true;
+        }
 
-                return sceneView.model.views.models
-                    .map(model => model && model.attributes)
-                    .filter(Boolean);
+        function resolveTargetViews(targetViewId) {
+            const sceneView = Knack.router.scene_view;
+            if (!sceneView || !sceneView.model || !sceneView.model.views) return [];
+
+            if (targetViewId) {
+                const viewModel = sceneView.model.views._byId[targetViewId];
+                return (viewModel && viewModel.attributes) ? [viewModel.attributes] : [];
             }
 
-            function ensureViewLoadPromise(viewAttr, parsedFormData, markLoaded, versionToken) {
-                if (!viewAttr) return Promise.resolve();
+            return sceneView.model.views.models
+                .map(model => model && model.attributes)
+                .filter(Boolean);
+        }
 
-                const existingLoad = viewLoadPromises.get(viewAttr.key);
-                if (existingLoad && existingLoad.version === versionToken) {
-                    return existingLoad.promise;
-                }
+        function ensureViewLoadPromise(viewAttr, parsedFormData, markLoaded, versionToken) {
+            if (!viewAttr || !isInsertCreateForm(viewAttr)) return Promise.resolve();
 
-                const loadPromise = loadDataForView(viewAttr, parsedFormData)
-                    .then(() => {
-                        if (isInsertCreateForm(viewAttr)) {
-                            markLoaded(viewAttr.key);
-                        }
-                    })
-                    .finally(() => {
-                        const cached = viewLoadPromises.get(viewAttr.key);
-                        if (cached && cached.promise === loadPromise) {
-                            viewLoadPromises.delete(viewAttr.key);
-                        }
-                    });
-
-                viewLoadPromises.set(viewAttr.key, { promise: loadPromise, version: versionToken });
-                return loadPromise;
+            const existingLoad = viewLoadPromises.get(viewAttr.key);
+            if (existingLoad && existingLoad.version === versionToken) {
+                return existingLoad.promise;
             }
+
+            const loadPromise = loadDataForView(viewAttr, parsedFormData)
+                .then(() => {
+                    markLoaded(viewAttr.key);
+                })
+                .finally(() => {
+                    const cached = viewLoadPromises.get(viewAttr.key);
+                    if (cached && cached.promise === loadPromise) {
+                        viewLoadPromises.delete(viewAttr.key);
+                    }
+                });
+
+            viewLoadPromises.set(viewAttr.key, { promise: loadPromise, version: versionToken });
+            return loadPromise;
         }
 
         function loadDataForView(viewAttr, parsedFormData) {
@@ -5243,22 +5270,21 @@ function Ktl($, appInfo) {
 
                 currentViews[targetViewId] = targetViewId;
 
-                const hasReloadLastValues = Boolean(
-                    ktlKeywords[targetViewId] &&
-                    ktlKeywords[targetViewId]._rlv
-                );
-
-                if (storedViewData.expiryDate) {
-                    const nowTs = Date.now();
-                    const expiryTime = Date.parse(storedViewData.expiryDate);
-                    if (!Number.isNaN(expiryTime) && expiryTime < nowTs) {
-                        delete parsedFormData[targetViewId];
-                        persistFormDataCache(parsedFormData);
-                        return finish();
-                    }
+                if (isStoredViewExpired(storedViewData)) {
+                    delete parsedFormData[targetViewId];
+                    persistFormDataCache(parsedFormData);
+                    return finish();
                 }
 
                 const keys = Object.keys(storedViewData).filter(key => key !== 'expiryDate');
+
+                const hydrators = {
+                    rich_text: ({ fieldId, fieldValue }) => hydrateRichTextField({ fieldId, fieldValue, viewId: targetViewId }),
+                    connection: ({ fieldId, fieldValue }) => hydrateConnectionField({ fieldId, fieldValue, viewId: targetViewId, formDataObj: parsedFormData }),
+                    multiple_choice: ({ fieldId, fieldValue, field }) => hydrateMultipleChoiceField({ fieldId, fieldValue, viewId: targetViewId, field }),
+                    boolean: ({ fieldId, fieldValue, field }) => hydrateBooleanField({ fieldId, fieldValue, viewId: targetViewId, field }),
+                    rating: ({ fieldId, fieldValue }) => hydrateRatingField({ fieldId, fieldValue, viewId: targetViewId })
+                };
 
                 for (const fieldKey of keys) {
                     const fieldIdMatch = fieldKey.match(/field_\d+/);
@@ -5283,42 +5309,25 @@ function Ktl($, appInfo) {
                         continue;
                     }
 
-                    if (fieldType === 'rich_text') {
-                        hydrateRichTextField({ fieldId, fieldValue, viewId: targetViewId });
-                    } else if (TEXT_DATA_TYPES.includes(fieldType)) {
+                    if (TEXT_DATA_TYPES.includes(fieldType)) {
                         hydrateTextField({
                             fieldId,
                             fieldKey,
                             fieldValue,
                             viewId: targetViewId,
                             field,
-                            formDataObj: parsedFormData,
-                            preserveFieldData: hasReloadLastValues
-                        });
-                    } else if (fieldType === 'connection') {
-                        hydrateConnectionField({
-                            fieldId,
-                            fieldValue,
-                            viewId: targetViewId,
                             formDataObj: parsedFormData
                         });
-                    } else if (fieldType === 'multiple_choice') {
-                        hydrateMultipleChoiceField({
-                            fieldId,
-                            fieldValue,
-                            viewId: targetViewId,
-                            field
-                        });
-                    } else if (fieldType === 'boolean') {
-                        hydrateBooleanField({
-                            fieldId,
-                            fieldValue,
-                            viewId: targetViewId,
-                            field
-                        });
-                    } else if (['password', 'file', 'image'].includes(fieldType)) {
-                        // Ignore.
-                    } else {
+                        continue;
+                    }
+
+                    const hydrator = hydrators[fieldType];
+                    if (hydrator) {
+                        hydrator({ fieldId, fieldValue, field });
+                        continue;
+                    }
+
+                    if (!['password', 'file', 'image'].includes(fieldType)) {
                         ktl.log.clog('purple', 'Unsupported field type: ' + fieldId + ', ' + fieldType);
                     }
                 }
@@ -5328,10 +5337,8 @@ function Ktl($, appInfo) {
                         console.warn('Persistent Form - connection hydration wait failed', targetViewId, error);
                     })
                     .finally(() => {
-                        if (!hasReloadLastValues) {
-                            delete parsedFormData[targetViewId];
-                        }
-
+                        // Keep cached data so the form can survive multiple refreshes;
+                        // cache is still cleared on submit, scene change, or expiry.
                         persistFormDataCache(parsedFormData);
                         finish();
                     });
@@ -5389,8 +5396,7 @@ function Ktl($, appInfo) {
             fieldValue,
             viewId,
             field,
-            formDataObj,
-            preserveFieldData = false
+            formDataObj
         }) {
             const viewElement = document.getElementById(viewId);
             if (!viewElement) return;
@@ -5410,7 +5416,7 @@ function Ktl($, appInfo) {
                 let element;
 
                 if (field.attributes.type === 'date_time' || field.attributes.type === 'timer') {
-                    element = document.getElementById(`${viewId}-${fieldKey}`);
+                    element = getDateTimeElement({ viewId, fieldId, fieldKey });
                 } else {
                     if (subField) {
                         const escapedSubField = escapeForCssIdentifier(subField);
@@ -5447,16 +5453,22 @@ function Ktl($, appInfo) {
                 subFields.forEach(subField => {
                     const currentValue = fieldData[subField];
                     setFieldText(currentValue, subField);
-                    if (!preserveFieldData) {
-                        delete fieldData[subField];
-                    }
                 });
             } else {
                 setFieldText(fieldValue);
-                if (!preserveFieldData && formDataObj[viewId]) {
-                    delete formDataObj[viewId][fieldKey];
-                }
             }
+        }
+
+        function getDateTimeElement({ viewId, fieldId, fieldKey }) {
+            const directId = document.getElementById(`${viewId}-${fieldKey}`);
+            if (directId) return directId;
+
+            for (const suffix of DATE_TIME_FIELD_SUFFIXES) {
+                const el = document.getElementById(`${viewId}-${fieldId}${suffix}`);
+                if (el) return el;
+            }
+
+            return null;
         }
 
         function hydrateConnectionField({ fieldId, fieldValue, viewId, formDataObj }) {
@@ -5539,6 +5551,21 @@ function Ktl($, appInfo) {
                     selectElement.value = fieldValue;
                     selectElement.dispatchEvent(new Event('change', { bubbles: true }));
                 }
+            }
+        }
+
+        function hydrateRatingField({ fieldId, fieldValue, viewId }) {
+            const widget = $(`#${viewId}-${fieldId}`);
+            if (!widget.length || typeof widget.rateit !== 'function') return;
+
+            const numericValue = Number(fieldValue);
+            if (Number.isNaN(numericValue)) return;
+
+            widget.rateit('value', numericValue);
+
+            const hiddenInput = document.getElementById(`${viewId}-${fieldId}-value`);
+            if (hiddenInput) {
+                hiddenInput.value = numericValue;
             }
         }
 
@@ -5689,7 +5716,6 @@ function Ktl($, appInfo) {
             state.handler = handler;
             $(document).on(eventName, handler);
         }
-
 
         function teardownConnectionHydrationState(viewId) {
             const state = CONNECTION_HYDRATION_QUEUE.get(viewId);


### PR DESCRIPTION
Refactors form data loading to enhance reliability, modularity, and error handling when restoring persistent form fields.  Knacks connection fields have a habit of loading later than the view and under past issues we have had they can mutate even after the knack connections load triggers.  Most of this refactor is to gurantee that the connections load the correct value. Introduces robust connection field hydration with retry logic and event-driven updates, reducing race conditions and ensuring consistent restoration across various field types.  Converted some code to vanilla JS ready for the KTL-NG (Not Chosen & Redactor as Jquery Plugins).

Improves maintainability by modularizing field hydration, handling corrupted storage, and optimizing field-specific logic.