### PR TITLE
feat: add Knavigator deep-link button to developer popup

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -32257,6 +32257,8 @@ function Ktl($, appInfo) {
     this.developerPopupTool = function () {
         if (!ktl.core.getCfg().enabled.devInfoPopup || !ktl.account.isDeveloper()) return;
 
+        const KNAVIGATOR_URL = 'https://av.knack.com/knavigator#search/';
+
         // Ensure repeated calls don't stack global handlers (a common cause of CPU spikes / tab crashes).
         $(document)
             .off('KTL.devPopupSetResultText.ktlDevPopup')
@@ -32560,6 +32562,18 @@ function Ktl($, appInfo) {
                 icon.style['background-repeat'] = 'no-repeat';
                 knackButton.appendChild(icon);
                 container.appendChild(knackButton);
+            }
+
+            // Knavigator deep link
+            const knavigatorTypes = ['scene_', 'view_', 'field_', 'object_'];
+            if (knavigatorTypes.some(type => text.startsWith(type))) {
+                const knavigatorButton = createButton('fa-search');
+                knavigatorButton.title = 'Open in Knavigator';
+                knavigatorButton.addEventListener('click', () => {
+                    const url = `${KNAVIGATOR_URL}?app=${Knack.application_id}&item=${text}`;
+                    window.open(url, 'knavigator');
+                });
+                container.appendChild(knavigatorButton);
             }
 
             return container;


### PR DESCRIPTION
## Summary
- Adds a magnifying glass icon (fa-search) to DevInfo popover rows for scene, view, field, and object items
- Clicking opens Knavigator in a reusable tab with the app ID and item pre-populated via deep link
- Uses existing `createButton()` factory for consistent styling

## Test plan
- [ ] Open Knack app with KTL local mode, Ctrl+Shift hover over a view/scene element
- [ ] Confirm magnifying glass icon appears on scene, view, field, and object rows
- [ ] Click it — should open Knavigator with correct deep link
- [ ] Click another item — should reuse the same Knavigator tab
- [ ] Confirm record rows do NOT show the icon