### PR TITLE
Fix findRecords filter merge to preserve caller boolean logic.

### DIFF
--- a/Docs/KTL_API.md
+++ b/Docs/KTL_API.md
@@ -11,6 +11,7 @@ This document describes the `this.api` module in `KTL.js`.
 - Optional debug logging with developer-role gating
 - Write queue controls (concurrency + rate limiting)
 - Bulk helpers for create/update/delete operations
+- Asset upload helper with retry/backoff and configurable size policy
 
 The module exposes a shared singleton API instance plus `create(options)` for custom instances.
 
@@ -64,6 +65,8 @@ Gets records from one view/page.
 Gets all pages from a view.
 
 - Supports `onProgress({ page, totalPages, recordsLoaded, totalRecords, percentage })`
+- Uses parallel page batches with partial recovery by default (`Promise.allSettled` behavior)
+- Optional `failOnPageError: true` to preserve fail-fast behavior if any page request fails
 
 ### `getRecord(viewId, recordId, options?)`
 Gets a single record by record id.
@@ -73,6 +76,9 @@ Gets child records linked by a connection field.
 
 ### `getAllChildRecords(viewId, recordId, connectionSlug, options?)`
 Gets all pages of child records.
+
+- Uses parallel page batches with partial recovery by default (`Promise.allSettled` behavior)
+- Optional `failOnPageError: true` to preserve fail-fast behavior if any child page request fails
 
 ---
 
@@ -94,6 +100,19 @@ Updates one record.
 Updates many records with queue controls.
 
 - Returns: `{ total, updated, failed }`
+- Supports two input shapes:
+  - Shared-data mode: `recordIds: string[]` + shared `recordData`
+  - Per-record mode: `recordIds: Array<{ id, data }>`
+- Mixed arrays (e.g., first item object, later items string IDs) now throw a clear validation error
+
+### `uploadAsset(file, options?)`
+Uploads one file/image asset and returns uploaded asset metadata.
+
+- Uses the same `_request` retry/backoff/timeout pipeline as other API methods
+- Supports size policy options:
+  - `warnAssetSizeBytes` (warn threshold)
+  - `maxAssetSizeBytes` (optional hard max)
+  - `enforceAssetSize` (reject early when max exceeded)
 
 ### `deleteRecord(viewId, recordId, refreshViews?, options?)`
 Deletes one record.
@@ -116,6 +135,11 @@ Builds Knack filter query params.
 ### `buildSorters(sorters)`
 Builds Knack sorter query params.
 
+### `findRecords(viewId, fieldId, value, options?)`
+Convenience wrapper that ANDs a base equality rule with caller filters.
+
+- Caller filter groups with `match/rules` are nested as a single rule to preserve caller boolean logic (including top-level `or` groups)
+
 ### `getApplication(applicationId?, options?)`
 Fetches Knack application details.
 
@@ -132,11 +156,18 @@ Many methods share these options:
 - `rows`: rows per page
 - `rawResponse`: return Knack raw payload instead of records array
 - `onProgress`: callback for paged or bulk operations
+- `failOnPageError`: when true, paged parallel reads throw if any page fails (default false = keep successful pages)
 
 Bulk write options:
 
 - `continueOnError` (default `false`)
 - `staggerMs` (default `0`)
+
+Asset upload options:
+
+- `warnAssetSizeBytes` (default `52428800`, i.e. 50MB)
+- `maxAssetSizeBytes` (default `null`, disabled)
+- `enforceAssetSize` (default `false`)
 
 ---
 
@@ -159,6 +190,9 @@ Defaults for a new instance:
 - `writeMinConcurrency: 1`
 - `writeMaxConcurrency: 8`
 - `writeRampDelayMs: 2000`
+- `warnAssetSizeBytes: 52428800`
+- `maxAssetSizeBytes: null`
+- `enforceAssetSize: false`
 
 ---
 
@@ -176,6 +210,7 @@ Defaults for a new instance:
 - Single write methods throw `Error` with `error.status` and `error.body` when available.
 - Bulk methods aggregate progress and return counts; with `continueOnError: false`, scheduling stops after first failure (already-started requests may still finish).
 - Bulk failure logging uses operation-specific KEC codes (`KEC_1028` create, `KEC_1029` update, `KEC_1030` delete, `KEC_1031` tags).
+- Paged reads (`getAllRecords`, `getAllChildRecords`) now keep successful pages even if one batch member fails, unless `failOnPageError` is enabled.
 
 ---
 

--- a/Docs/KTL_API.md
+++ b/Docs/KTL_API.md
@@ -132,13 +132,16 @@ Refreshes one or many views.
 ### `buildFilters(filters)`
 Builds Knack filter query params.
 
+- Nested filter groups are rejected with a clear error because Knack does not reliably support nested group logic.
+
 ### `buildSorters(sorters)`
 Builds Knack sorter query params.
 
 ### `findRecords(viewId, fieldId, value, options?)`
 Convenience wrapper that ANDs a base equality rule with caller filters.
 
-- Caller filter groups with `match/rules` are nested as a single rule to preserve caller boolean logic (including top-level `or` groups)
+- Grouped caller filters are supported only when `match: 'and'` and rules are flat (non-nested).
+- Grouped `or` logic is rejected with a clear error; use separate queries and merge client-side.
 
 ### `getApplication(applicationId?, options?)`
 Fetches Knack application details.

--- a/KTL.js
+++ b/KTL.js
@@ -4666,7 +4666,9 @@ function Ktl($, appInfo) {
             async createRecord(viewId, recordData, refreshViews, options = {}) {
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId);
-                const effectiveRefresh = opts.refreshViews !== undefined ? opts.refreshViews : refreshViews;
+                const effectiveRefresh = this._normalizeRefreshViews(
+                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
+                );
 
                 const preparedRecordData = await this._prepareRecordData(recordData, opts);
 
@@ -4715,7 +4717,9 @@ function Ktl($, appInfo) {
                 const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, options, () => {
                     rateLimit429Count += 1;
                 });
-                const effectiveRefresh = opts.refreshViews !== undefined ? opts.refreshViews : refreshViews;
+                const effectiveRefresh = this._normalizeRefreshViews(
+                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
+                );
 
                 try {
                     const batchResult = await this._runBatchWorkers({
@@ -4796,7 +4800,7 @@ function Ktl($, appInfo) {
                 const enforceAssetSize = opts.enforceAssetSize === true
                     ? true
                     : (opts.enforceAssetSize === false ? false : this.options.enforceAssetSize);
-                const fileName = typeof file?.name === 'string' ? file.name : 'upload.bin';
+                const uploadFileName = typeof file?.name === 'string' && file.name.length ? file.name : 'upload.bin';
                 const exceedsWarnThreshold = hasKnownFileSize
                     && Number.isFinite(warnAssetSizeBytes)
                     && warnAssetSizeBytes >= 0
@@ -4812,7 +4816,7 @@ function Ktl($, appInfo) {
                     }
 
                     this._log('Asset upload size is unavailable; proceeding without size validation', {
-                        fileName,
+                        fileName: uploadFileName,
                         fileType: file?.type || '',
                         fileSizeRaw: file?.size,
                         warnAssetSizeBytes,
@@ -4826,7 +4830,7 @@ function Ktl($, appInfo) {
                     }
 
                     this._log('Asset upload exceeds configured max size but enforcement is disabled', {
-                        fileName,
+                        fileName: uploadFileName,
                         fileSizeBytes,
                         maxAssetSizeBytes,
                         fileSizeLabel: this._formatByteSize(fileSizeBytes),
@@ -4834,7 +4838,7 @@ function Ktl($, appInfo) {
                     }, 'warn');
                 } else if (exceedsWarnThreshold) {
                     this._log('Asset upload exceeds warning threshold', {
-                        fileName,
+                        fileName: uploadFileName,
                         fileSizeBytes,
                         warnAssetSizeBytes,
                         fileSizeLabel: this._formatByteSize(fileSizeBytes),
@@ -4843,7 +4847,6 @@ function Ktl($, appInfo) {
                 }
 
                 const formData = new FormData();
-                const uploadFileName = typeof file?.name === 'string' && file.name.length ? file.name : 'upload.bin';
                 formData.append('files', file, uploadFileName);
 
                 const timeoutMs = Number.isFinite(opts.timeout) ? opts.timeout : this.options.timeout;
@@ -4942,7 +4945,9 @@ function Ktl($, appInfo) {
             async updateRecord(viewId, recordId, recordData, refreshViews, options = {}) {
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId, recordId);
-                const effectiveRefresh = opts.refreshViews !== undefined ? opts.refreshViews : refreshViews;
+                const effectiveRefresh = this._normalizeRefreshViews(
+                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
+                );
                 const preparedRecordData = await this._prepareRecordData(recordData, opts);
                 return await this._enqueueWrite(async () => {
                     const result = await this._request(
@@ -5002,13 +5007,16 @@ function Ktl($, appInfo) {
                 if (isPerRecord) {
                     // updateRecords(viewId, [{id, data}, ...], refreshViews, options)
                     records = recordIds.filter(r => r && r.id);
-                    opts = refreshViews || {};
-                    effectiveRefresh = opts?.refreshViews !== undefined ? opts.refreshViews : recordData; // positional shift
+                    opts = (refreshViews && typeof refreshViews === 'object' && !Array.isArray(refreshViews)) ? refreshViews : {};
+                    effectiveRefresh = opts?.refreshViews !== undefined
+                        ? opts.refreshViews
+                        : recordData; // positional shift
                 } else {
                     records = (Array.isArray(recordIds) ? recordIds.filter(Boolean) : []).map(id => ({ id, data: recordData }));
                     effectiveRefresh = options?.refreshViews !== undefined ? options.refreshViews : refreshViews;
                     opts = options || {};
                 }
+                effectiveRefresh = this._normalizeRefreshViews(effectiveRefresh);
 
                 const total = records.length;
                 if (!total) return { total: 0, updated: 0, failed: 0 };
@@ -5073,7 +5081,9 @@ function Ktl($, appInfo) {
              */
             async deleteRecord(viewId, recordId, refreshViews, options = {}) {
                 const opts = options || {};
-                const effectiveRefresh = opts.refreshViews !== undefined ? opts.refreshViews : refreshViews;
+                const effectiveRefresh = this._normalizeRefreshViews(
+                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
+                );
                 const url = this._formatApiUrl(viewId, recordId);
                 return await this._enqueueWrite(async () => {
                     const result = await this._request(
@@ -5115,7 +5125,9 @@ function Ktl($, appInfo) {
                 const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, options, () => {
                     rateLimit429Count += 1;
                 });
-                const effectiveRefresh = opts.refreshViews !== undefined ? opts.refreshViews : refreshViews;
+                const effectiveRefresh = this._normalizeRefreshViews(
+                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
+                );
 
                 try {
                     const batchResult = await this._runBatchWorkers({
@@ -5928,6 +5940,25 @@ function Ktl($, appInfo) {
             async _refreshAfterWrite(refreshViews) {
                 if (!refreshViews) return;
                 await this.refreshView(refreshViews);
+            }
+
+            /**
+             * Normalize refresh target input to a valid view id string or string array.
+             * @param {string|string[]|*} refreshViews
+             * @returns {string|string[]|null}
+             * @private
+             */
+            _normalizeRefreshViews(refreshViews) {
+                if (typeof refreshViews === 'string') {
+                    return refreshViews;
+                }
+
+                if (Array.isArray(refreshViews)) {
+                    const normalized = refreshViews.filter(viewId => typeof viewId === 'string' && viewId.length);
+                    return normalized.length ? normalized : null;
+                }
+
+                return null;
             }
 
             /**

--- a/KTL.js
+++ b/KTL.js
@@ -4784,7 +4784,7 @@ function Ktl($, appInfo) {
                 const url = `${base}/applications/${appId}/assets/${assetType}/upload`;
 
                 const hasKnownFileSize = Number.isFinite(file?.size);
-                const fileSizeBytes = hasKnownFileSize ? file.size : 0;
+                const fileSizeBytes = hasKnownFileSize ? file.size : null;
                 const warnAssetSizeBytes = Number.isFinite(opts.warnAssetSizeBytes) && opts.warnAssetSizeBytes >= 0
                     ? opts.warnAssetSizeBytes
                     : this.options.warnAssetSizeBytes;
@@ -4796,21 +4796,45 @@ function Ktl($, appInfo) {
                 const enforceAssetSize = opts.enforceAssetSize === true
                     ? true
                     : (opts.enforceAssetSize === false ? false : this.options.enforceAssetSize);
+                const fileName = typeof file?.name === 'string' ? file.name : 'upload.bin';
+                const exceedsWarnThreshold = hasKnownFileSize
+                    && Number.isFinite(warnAssetSizeBytes)
+                    && warnAssetSizeBytes >= 0
+                    && fileSizeBytes > warnAssetSizeBytes;
+                const exceedsMaxThreshold = hasKnownFileSize
+                    && Number.isFinite(maxAssetSizeBytes)
+                    && maxAssetSizeBytes > 0
+                    && fileSizeBytes > maxAssetSizeBytes;
 
                 if (!hasKnownFileSize) {
-                    this._log('Asset upload size is unavailable; skipping size warning/enforcement thresholds for this file', {
-                        fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
+                    if (enforceAssetSize && Number.isFinite(maxAssetSizeBytes) && maxAssetSizeBytes > 0) {
+                        throw new Error('KTL API error: uploadAsset cannot validate file size because the file size is unavailable and asset size enforcement is enabled.');
+                    }
+
+                    this._log('Asset upload size is unavailable; proceeding without size validation', {
+                        fileName,
                         fileType: file?.type || '',
                         fileSizeRaw: file?.size,
                         warnAssetSizeBytes,
                         maxAssetSizeBytes,
                         enforceAssetSize
                     }, 'warn');
-                }
+                } else if (exceedsMaxThreshold) {
+                    const sizeMessage = `KTL API error: uploadAsset file size ${this._formatByteSize(fileSizeBytes)} exceeds configured max ${this._formatByteSize(maxAssetSizeBytes)}.`;
+                    if (enforceAssetSize) {
+                        throw new Error(sizeMessage);
+                    }
 
-                if (hasKnownFileSize && Number.isFinite(warnAssetSizeBytes) && warnAssetSizeBytes >= 0 && fileSizeBytes > warnAssetSizeBytes) {
+                    this._log('Asset upload exceeds configured max size but enforcement is disabled', {
+                        fileName,
+                        fileSizeBytes,
+                        maxAssetSizeBytes,
+                        fileSizeLabel: this._formatByteSize(fileSizeBytes),
+                        maxSizeLabel: this._formatByteSize(maxAssetSizeBytes)
+                    }, 'warn');
+                } else if (exceedsWarnThreshold) {
                     this._log('Asset upload exceeds warning threshold', {
-                        fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
+                        fileName,
                         fileSizeBytes,
                         warnAssetSizeBytes,
                         fileSizeLabel: this._formatByteSize(fileSizeBytes),
@@ -4818,24 +4842,9 @@ function Ktl($, appInfo) {
                     }, 'warn');
                 }
 
-                if (hasKnownFileSize && Number.isFinite(maxAssetSizeBytes) && maxAssetSizeBytes > 0 && fileSizeBytes > maxAssetSizeBytes) {
-                    const sizeMessage = `KTL API error: uploadAsset file size ${this._formatByteSize(fileSizeBytes)} exceeds configured max ${this._formatByteSize(maxAssetSizeBytes)}.`;
-                    if (enforceAssetSize) {
-                        throw new Error(sizeMessage);
-                    }
-
-                    this._log('Asset upload exceeds configured max size but enforcement is disabled', {
-                        fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
-                        fileSizeBytes,
-                        maxAssetSizeBytes,
-                        fileSizeLabel: this._formatByteSize(fileSizeBytes),
-                        maxSizeLabel: this._formatByteSize(maxAssetSizeBytes)
-                    }, 'warn');
-                }
-
                 const formData = new FormData();
-                const fileName = typeof file?.name === 'string' && file.name.length ? file.name : 'upload.bin';
-                formData.append('files', file, fileName);
+                const uploadFileName = typeof file?.name === 'string' && file.name.length ? file.name : 'upload.bin';
+                formData.append('files', file, uploadFileName);
 
                 const timeoutMs = Number.isFinite(opts.timeout) ? opts.timeout : this.options.timeout;
 
@@ -5963,70 +5972,190 @@ function Ktl($, appInfo) {
                 return apiInstance.canLog();
             },
 
+            /**
+             * Get records from a view.
+             * @param {string} viewId
+             * @param {Object} [options]
+             * @returns {Promise<Array<Object>|Object>}
+             */
             getRecords: function (...args) {
                 return apiInstance.getRecords(...args);
             },
 
+            /**
+             * Get all records from a view across pages.
+             * @param {string} viewId
+             * @param {Object} [options]
+             * @returns {Promise<Array<Object>>}
+             */
             getAllRecords: function (...args) {
                 return apiInstance.getAllRecords(...args);
             },
 
+            /**
+             * Fetch a single record by ID.
+             * @param {string} viewId
+             * @param {string} recordId
+             * @param {Object} [options]
+             * @returns {Promise<Object>}
+             */
             getRecord: function (...args) {
                 return apiInstance.getRecord(...args);
             },
 
+            /**
+             * Fetch child records connected to a parent record.
+             * @param {string} viewId
+             * @param {string} recordId
+             * @param {string} connectionSlug
+             * @param {Object} [options]
+             * @returns {Promise<Array<Object>|Object>}
+             */
             getChildRecords: function (...args) {
                 return apiInstance.getChildRecords(...args);
             },
 
+            /**
+             * Fetch all connected child records across pages.
+             * @param {string} viewId
+             * @param {string} recordId
+             * @param {string} connectionSlug
+             * @param {Object} [options]
+             * @returns {Promise<Array<Object>>}
+             */
             getAllChildRecords: function (...args) {
                 return apiInstance.getAllChildRecords(...args);
             },
 
+            /**
+             * Create a record in a view.
+             * @param {string} viewId
+             * @param {Object} recordData
+             * @param {Array|string} [refreshViews]
+             * @param {Object} [options]
+             * @returns {Promise<Object>}
+             */
             createRecord: function (...args) {
                 return apiInstance.createRecord(...args);
             },
 
+            /**
+             * Create multiple records in a view.
+             * @param {string} viewId
+             * @param {Object[]} recordsData
+             * @param {Array|string} [refreshViews]
+             * @param {Object} [options]
+             * @returns {Promise<{ total: number, created: number, failed: number, records: Object[] }>}
+             */
             createRecords: function (...args) {
                 return apiInstance.createRecords(...args);
             },
 
+            /**
+             * Upload a file or image asset.
+             * @param {File|Blob} file
+             * @param {Object} [options]
+             * @returns {Promise<Object>}
+             */
             uploadAsset: function (...args) {
                 return apiInstance.uploadAsset(...args);
             },
 
+            /**
+             * Update a record in a view.
+             * @param {string} viewId
+             * @param {string} recordId
+             * @param {Object} recordData
+             * @param {Array|string} [refreshViews]
+             * @param {Object} [options]
+             * @returns {Promise<Object>}
+             */
             updateRecord: function (...args) {
                 return apiInstance.updateRecord(...args);
             },
 
+            /**
+             * Update multiple records in a view.
+             * @param {string} viewId
+             * @param {string[]|Array<{id:string,data:Object}>} recordIds
+             * @param {Object|Array|string} recordData
+             * @param {Array|string} [refreshViews]
+             * @param {Object} [options]
+             * @returns {Promise<{ total: number, updated: number, failed: number }>}
+             */
             updateRecords: function (...args) {
                 return apiInstance.updateRecords(...args);
             },
 
+            /**
+             * Delete a record in a view.
+             * @param {string} viewId
+             * @param {string} recordId
+             * @param {Array|string} [refreshViews]
+             * @param {Object} [options]
+             * @returns {Promise<Object>}
+             */
             deleteRecord: function (...args) {
                 return apiInstance.deleteRecord(...args);
             },
 
+            /**
+             * Delete multiple records in a view.
+             * @param {string} viewId
+             * @param {string[]} recordIds
+             * @param {Array|string} [refreshViews]
+             * @param {Object} [options]
+             * @returns {Promise<{ total: number, deleted: number, failed: number }>}
+             */
             deleteRecords: function (...args) {
                 return apiInstance.deleteRecords(...args);
             },
 
+            /**
+             * Find records by field/value matching.
+             * @param {string} viewId
+             * @param {string} fieldId
+             * @param {*} value
+             * @param {Object} [options]
+             * @returns {Promise<Array<Object>>}
+             */
             findRecords: function (...args) {
                 return apiInstance.findRecords(...args);
             },
 
+            /**
+             * Refresh one or more views.
+             * @param {string|string[]} viewId
+             * @returns {Promise<void|void[]>}
+             */
             refreshView: function (...args) {
                 return apiInstance.refreshView(...args);
             },
 
+            /**
+             * Build Knack filter query params.
+             * @param {Array<Object>|Object} filters
+             * @returns {Object}
+             */
             buildFilters: function (...args) {
                 return apiInstance.buildFilters(...args);
             },
 
+            /**
+             * Build Knack sorter query params.
+             * @param {Array<Object>|Object} sorters
+             * @returns {Object}
+             */
             buildSorters: function (...args) {
                 return apiInstance.buildSorters(...args);
             },
 
+            /**
+             * Fetch application details.
+             * @param {string} [applicationId]
+             * @param {Object} [options]
+             * @returns {Promise<Object>}
+             */
             getApplication: function (...args) {
                 return apiInstance.getApplication(...args);
             }

--- a/KTL.js
+++ b/KTL.js
@@ -4367,6 +4367,9 @@ function Ktl($, appInfo) {
          * @property {number} [writeMinConcurrency=1] - Min concurrency after rate limiting.
          * @property {number} [writeMaxConcurrency=8] - Upper bound for adaptive concurrency. Max 8 allows scaling to 80% of Knack's 10 API/sec limit.
          * @property {number} [writeRampDelayMs=2000] - Delay before ramping concurrency.
+         * @property {number|null} [maxAssetSizeBytes=null] - Optional hard max upload size in bytes. `null` disables max-size enforcement.
+         * @property {number} [warnAssetSizeBytes=52428800] - Warn threshold in bytes (default 50MB).
+         * @property {boolean} [enforceAssetSize=false] - When true, reject uploads above `maxAssetSizeBytes` before network request.
          */
 
         class KtlKnackApi {
@@ -4399,7 +4402,14 @@ function Ktl($, appInfo) {
                     writeRatePerSecond: Number.isFinite(options.writeRatePerSecond) ? options.writeRatePerSecond : 9,
                     writeMinConcurrency: Number.isFinite(options.writeMinConcurrency) ? options.writeMinConcurrency : 1,
                     writeMaxConcurrency: Number.isFinite(options.writeMaxConcurrency) ? options.writeMaxConcurrency : 8,
-                    writeRampDelayMs: Number.isFinite(options.writeRampDelayMs) ? options.writeRampDelayMs : 2000
+                    writeRampDelayMs: Number.isFinite(options.writeRampDelayMs) ? options.writeRampDelayMs : 2000,
+                    maxAssetSizeBytes: Number.isFinite(options.maxAssetSizeBytes) && options.maxAssetSizeBytes > 0
+                        ? options.maxAssetSizeBytes
+                        : null,
+                    warnAssetSizeBytes: Number.isFinite(options.warnAssetSizeBytes) && options.warnAssetSizeBytes >= 0
+                        ? options.warnAssetSizeBytes
+                        : (50 * 1024 * 1024),
+                    enforceAssetSize: options.enforceAssetSize === true
                 };
 
                 this._initLogSettings();
@@ -4451,6 +4461,7 @@ function Ktl($, appInfo) {
                     ? Math.floor(opts.pageConcurrency)
                     : 5;
                 const pageOpts = { filters: opts.filters, sorters: opts.sorters, rows, rawResponse: true, timeout: opts.timeout };
+                const failOnPageError = Boolean(opts.failOnPageError);
 
                 const firstPage = await this.getRecords(viewId, { ...pageOpts, page: 1 });
 
@@ -4466,12 +4477,29 @@ function Ktl($, appInfo) {
                     const pageNumbers = [];
                     for (let p = batchStart; p <= batchEnd; p++) pageNumbers.push(p);
 
-                    const batchResults = await Promise.all(
+                    const batchResults = await Promise.allSettled(
                         pageNumbers.map(page => this.getRecords(viewId, { ...pageOpts, page }))
                     );
 
-                    for (const nextPage of batchResults) {
-                        if (Array.isArray(nextPage?.records)) allRecords.push(...nextPage.records);
+                    for (let i = 0; i < batchResults.length; i++) {
+                        const result = batchResults[i];
+                        const page = pageNumbers[i];
+
+                        if (result.status === 'fulfilled') {
+                            const nextPage = result.value;
+                            if (Array.isArray(nextPage?.records)) allRecords.push(...nextPage.records);
+                            continue;
+                        }
+
+                        this._log('Page fetch failed', {
+                            viewId,
+                            page,
+                            error: result.reason?.message || result.reason
+                        }, 'warn');
+
+                        if (failOnPageError) {
+                            throw result.reason;
+                        }
                     }
 
                     if (typeof opts.onProgress === 'function') {
@@ -4534,6 +4562,7 @@ function Ktl($, appInfo) {
                     ? Math.floor(opts.pageConcurrency)
                     : 5;
                 const pageOpts = { filters: opts.filters, sorters: opts.sorters, rows, rawResponse: true, timeout: opts.timeout };
+                const failOnPageError = Boolean(opts.failOnPageError);
 
                 const firstPage = await this.getChildRecords(viewId, recordId, connectionSlug, { ...pageOpts, page: 1 });
 
@@ -4549,12 +4578,31 @@ function Ktl($, appInfo) {
                     const pageNumbers = [];
                     for (let p = batchStart; p <= batchEnd; p++) pageNumbers.push(p);
 
-                    const batchResults = await Promise.all(
+                    const batchResults = await Promise.allSettled(
                         pageNumbers.map(page => this.getChildRecords(viewId, recordId, connectionSlug, { ...pageOpts, page }))
                     );
 
-                    for (const nextPage of batchResults) {
-                        if (Array.isArray(nextPage?.records)) allRecords.push(...nextPage.records);
+                    for (let i = 0; i < batchResults.length; i++) {
+                        const result = batchResults[i];
+                        const page = pageNumbers[i];
+
+                        if (result.status === 'fulfilled') {
+                            const nextPage = result.value;
+                            if (Array.isArray(nextPage?.records)) allRecords.push(...nextPage.records);
+                            continue;
+                        }
+
+                        this._log('Child page fetch failed', {
+                            viewId,
+                            recordId,
+                            connectionSlug,
+                            page,
+                            error: result.reason?.message || result.reason
+                        }, 'warn');
+
+                        if (failOnPageError) {
+                            throw result.reason;
+                        }
                     }
 
                     if (typeof opts.onProgress === 'function') {
@@ -4586,7 +4634,7 @@ function Ktl($, appInfo) {
 
                 if (opts.filters) {
                     if (opts.filters.match && Array.isArray(opts.filters.rules)) {
-                        mergedFilters = { match: 'and', rules: [baseRule, ...opts.filters.rules] };
+                        mergedFilters = { match: 'and', rules: [baseRule, opts.filters] };
                     } else {
                         mergedFilters = { match: 'and', rules: [baseRule, opts.filters] };
                     }
@@ -4706,6 +4754,9 @@ function Ktl($, appInfo) {
              * @param {Object} [options]
              * @param {'file'|'image'} [options.assetType] - Optional override. Auto-detected from mime type when omitted.
              * @param {number} [options.timeout]
+             * @param {number|null} [options.maxAssetSizeBytes] - Optional per-call max upload size in bytes. `null` disables max-size enforcement.
+             * @param {number} [options.warnAssetSizeBytes] - Optional per-call warning threshold in bytes.
+             * @param {boolean} [options.enforceAssetSize] - Optional per-call override for max-size enforcement.
              * @returns {Promise<Object>} Uploaded asset payload (must include `id`).
              */
             async uploadAsset(file, options = {}) {
@@ -4724,6 +4775,44 @@ function Ktl($, appInfo) {
                 const base = this._getApiBaseUrl().replace(/\/$/, '');
                 const url = `${base}/applications/${appId}/assets/${assetType}/upload`;
 
+                const fileSizeBytes = Number.isFinite(file?.size) ? file.size : 0;
+                const warnAssetSizeBytes = Number.isFinite(opts.warnAssetSizeBytes) && opts.warnAssetSizeBytes >= 0
+                    ? opts.warnAssetSizeBytes
+                    : this.options.warnAssetSizeBytes;
+                const maxAssetSizeBytes = (opts.maxAssetSizeBytes === null)
+                    ? null
+                    : (Number.isFinite(opts.maxAssetSizeBytes) && opts.maxAssetSizeBytes > 0
+                        ? opts.maxAssetSizeBytes
+                        : this.options.maxAssetSizeBytes);
+                const enforceAssetSize = opts.enforceAssetSize === true
+                    ? true
+                    : (opts.enforceAssetSize === false ? false : this.options.enforceAssetSize);
+
+                if (Number.isFinite(warnAssetSizeBytes) && warnAssetSizeBytes >= 0 && fileSizeBytes > warnAssetSizeBytes) {
+                    this._log('Asset upload exceeds warning threshold', {
+                        fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
+                        fileSizeBytes,
+                        warnAssetSizeBytes,
+                        fileSizeLabel: this._formatByteSize(fileSizeBytes),
+                        warnSizeLabel: this._formatByteSize(warnAssetSizeBytes)
+                    }, 'warn');
+                }
+
+                if (Number.isFinite(maxAssetSizeBytes) && maxAssetSizeBytes > 0 && fileSizeBytes > maxAssetSizeBytes) {
+                    const sizeMessage = `KTL API error: uploadAsset file size ${this._formatByteSize(fileSizeBytes)} exceeds configured max ${this._formatByteSize(maxAssetSizeBytes)}.`;
+                    if (enforceAssetSize) {
+                        throw new Error(sizeMessage);
+                    }
+
+                    this._log('Asset upload exceeds configured max size but enforcement is disabled', {
+                        fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
+                        fileSizeBytes,
+                        maxAssetSizeBytes,
+                        fileSizeLabel: this._formatByteSize(fileSizeBytes),
+                        maxSizeLabel: this._formatByteSize(maxAssetSizeBytes)
+                    }, 'warn');
+                }
+
                 const formData = new FormData();
                 const fileName = typeof file?.name === 'string' && file.name.length ? file.name : 'upload.bin';
                 formData.append('files', file, fileName);
@@ -4731,49 +4820,24 @@ function Ktl($, appInfo) {
                 const timeoutMs = Number.isFinite(opts.timeout) ? opts.timeout : this.options.timeout;
 
                 return await this._enqueueWrite(async () => {
-                    const controller = new AbortController();
-                    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-                    this._toggleSpinner(true);
-                    try {
-                        const response = await fetch(url, {
+                    const result = await this._request(
+                        url,
+                        {
                             method: 'POST',
                             headers: this._buildUploadHeaders(),
                             body: formData,
-                            signal: controller.signal
-                        });
+                            rateLimitHandler: (delayMs) => this._notifyWriteRateLimit(delayMs),
+                            onRateLimit429: typeof opts._on429 === 'function' ? opts._on429 : null
+                        },
+                        timeoutMs
+                    );
 
-                        const responseText = await response.text();
-                        if (!response.ok) {
-                            throw this._buildRequestError({
-                                status: response.status,
-                                statusText: response.statusText,
-                                responseText,
-                                headers: response.headers
-                            });
-                        }
-
-                        let parsed;
-                        try {
-                            parsed = responseText ? JSON.parse(responseText) : {};
-                        } catch (e) {
-                            parsed = responseText || {};
-                        }
-
-                        const asset = Array.isArray(parsed) ? parsed[0] : parsed;
-                        if (!asset || !asset.id) {
-                            throw new Error('KTL API error: asset upload succeeded but no asset id was returned.');
-                        }
-
-                        return asset;
-                    } catch (error) {
-                        if (error?.name === 'AbortError') {
-                            throw this._buildRequestError({ status: 0, statusText: 'Request timeout', responseText: '' });
-                        }
-                        throw error;
-                    } finally {
-                        clearTimeout(timeoutId);
-                        this._toggleSpinner(false);
+                    const asset = Array.isArray(result) ? result[0] : result;
+                    if (!asset || !asset.id) {
+                        throw new Error('KTL API error: asset upload succeeded but no asset id was returned.');
                     }
+
+                    return asset;
                 });
             }
 
@@ -4890,10 +4954,20 @@ function Ktl($, appInfo) {
                 // Detect per-record shape: Array<{id, data}>
                 const isPerRecord = Array.isArray(recordIds)
                     && recordIds.length > 0
-                    && recordIds[0] !== null
-                    && typeof recordIds[0] === 'object'
-                    && 'id' in recordIds[0]
-                    && 'data' in recordIds[0];
+                    && recordIds.every(record =>
+                        record !== null
+                        && typeof record === 'object'
+                        && 'id' in record
+                        && 'data' in record
+                    );
+
+                const hasMixedPerRecordShape = Array.isArray(recordIds)
+                    && recordIds.some(record => record !== null && typeof record === 'object')
+                    && !isPerRecord;
+
+                if (hasMixedPerRecordShape) {
+                    throw new Error('KTL API error: updateRecords received a mixed array. Use all IDs with shared data, or all objects with {id, data}.');
+                }
 
                 let records, effectiveRefresh, opts;
                 if (isPerRecord) {
@@ -5574,9 +5648,10 @@ function Ktl($, appInfo) {
                         const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
                         try {
+                            const headers = requestOptions.headers || this._buildHeaders();
                             const fetchOptions = {
                                 method,
-                                headers: this._buildHeaders(),
+                                headers,
                                 signal: controller.signal
                             };
 
@@ -5674,13 +5749,6 @@ function Ktl($, appInfo) {
              */
             _buildRequestError(jqXHR) {
                 const status = jqXHR?.status || 0;
-                // Accept plain objects with responseText (our internal convention).
-                // Also tolerate fetch Response-like objects where body text may not be pre-read.
-                const hasResponseLikeShape = !!jqXHR && typeof jqXHR === 'object'
-                    && typeof jqXHR.status === 'number'
-                    && typeof jqXHR.statusText === 'string'
-                    && typeof jqXHR.text === 'function';
-
                 const responseText = typeof jqXHR?.responseText === 'string'
                     ? jqXHR.responseText
                     : (typeof jqXHR?.body === 'string' ? jqXHR.body : '');
@@ -5691,10 +5759,6 @@ function Ktl($, appInfo) {
                     message = json?.message || json?.error || message;
                 } catch (e) {
                     // ignore parse errors
-                }
-
-                if (!responseText && hasResponseLikeShape) {
-                    message = `${message} (response body not pre-read)`;
                 }
 
                 const error = new Error(`API error ${status}: ${message}`);
@@ -5787,6 +5851,21 @@ function Ktl($, appInfo) {
                 if (level === 'warn') console.warn(prefix, payload);
                 else if (level === 'error') console.error(prefix, payload);
                 else console.log(prefix, payload);
+            }
+
+            /**
+             * Format bytes into a human-readable label.
+             * @param {number} bytes
+             * @returns {string}
+             * @private
+             */
+            _formatByteSize(bytes) {
+                if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+                const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+                if (bytes === 0) return '0 B';
+                const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+                const value = bytes / Math.pow(1024, exponent);
+                return `${value.toFixed(exponent === 0 ? 0 : 2)} ${units[exponent]}`;
             }
 
             /**

--- a/KTL.js
+++ b/KTL.js
@@ -4973,8 +4973,8 @@ function Ktl($, appInfo) {
                 if (isPerRecord) {
                     // updateRecords(viewId, [{id, data}, ...], refreshViews, options)
                     records = recordIds.filter(r => r && r.id);
-                    effectiveRefresh = recordData; // positional shift
                     opts = refreshViews || {};
+                    effectiveRefresh = opts?.refreshViews !== undefined ? opts.refreshViews : recordData; // positional shift
                 } else {
                     records = (Array.isArray(recordIds) ? recordIds.filter(Boolean) : []).map(id => ({ id, data: recordData }));
                     effectiveRefresh = options?.refreshViews !== undefined ? options.refreshViews : refreshViews;

--- a/KTL.js
+++ b/KTL.js
@@ -4634,7 +4634,15 @@ function Ktl($, appInfo) {
 
                 if (opts.filters) {
                     if (opts.filters.match && Array.isArray(opts.filters.rules)) {
-                        mergedFilters = { match: 'and', rules: [baseRule, opts.filters] };
+                        if (this._hasNestedFilterGroups(opts.filters)) {
+                            throw new Error('KTL API error: nested filter groups are not supported by Knack. Use flat rules or separate API calls and merge results.');
+                        }
+
+                        if (String(opts.filters.match).toLowerCase() !== 'and') {
+                            throw new Error('KTL API error: findRecords cannot merge grouped filters unless match is "and". Use separate queries and merge results for "or" logic.');
+                        }
+
+                        mergedFilters = { match: 'and', rules: [baseRule, ...opts.filters.rules] };
                     } else {
                         mergedFilters = { match: 'and', rules: [baseRule, opts.filters] };
                     }
@@ -5172,6 +5180,10 @@ function Ktl($, appInfo) {
                 if (!filters) return {};
 
                 if (filters.match && filters.rules) {
+                    if (this._hasNestedFilterGroups(filters)) {
+                        throw new Error('KTL API error: nested filter groups are not supported by Knack. Use flat rules or run separate queries and merge results.');
+                    }
+
                     return { filters: JSON.stringify(filters) };
                 }
 
@@ -5217,6 +5229,24 @@ function Ktl($, appInfo) {
                 });
 
                 return formatted;
+            }
+
+            /**
+             * Returns true when any rule contains a nested match/rules group.
+             * @param {Object} filters
+             * @returns {boolean}
+             * @private
+             */
+            _hasNestedFilterGroups(filters) {
+                if (!filters || !Array.isArray(filters.rules)) return false;
+
+                const hasNestedRule = (rule) => {
+                    if (!rule || typeof rule !== 'object') return false;
+                    if (rule.match && Array.isArray(rule.rules)) return true;
+                    return false;
+                };
+
+                return filters.rules.some(hasNestedRule);
             }
 
             /**

--- a/KTL.js
+++ b/KTL.js
@@ -4783,7 +4783,8 @@ function Ktl($, appInfo) {
                 const base = this._getApiBaseUrl().replace(/\/$/, '');
                 const url = `${base}/applications/${appId}/assets/${assetType}/upload`;
 
-                const fileSizeBytes = Number.isFinite(file?.size) ? file.size : 0;
+                const hasKnownFileSize = Number.isFinite(file?.size);
+                const fileSizeBytes = hasKnownFileSize ? file.size : 0;
                 const warnAssetSizeBytes = Number.isFinite(opts.warnAssetSizeBytes) && opts.warnAssetSizeBytes >= 0
                     ? opts.warnAssetSizeBytes
                     : this.options.warnAssetSizeBytes;
@@ -4796,7 +4797,18 @@ function Ktl($, appInfo) {
                     ? true
                     : (opts.enforceAssetSize === false ? false : this.options.enforceAssetSize);
 
-                if (Number.isFinite(warnAssetSizeBytes) && warnAssetSizeBytes >= 0 && fileSizeBytes > warnAssetSizeBytes) {
+                if (!hasKnownFileSize) {
+                    this._log('Asset upload size is unavailable; skipping size warning/enforcement thresholds for this file', {
+                        fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
+                        fileType: file?.type || '',
+                        fileSizeRaw: file?.size,
+                        warnAssetSizeBytes,
+                        maxAssetSizeBytes,
+                        enforceAssetSize
+                    }, 'warn');
+                }
+
+                if (hasKnownFileSize && Number.isFinite(warnAssetSizeBytes) && warnAssetSizeBytes >= 0 && fileSizeBytes > warnAssetSizeBytes) {
                     this._log('Asset upload exceeds warning threshold', {
                         fileName: typeof file?.name === 'string' ? file.name : 'upload.bin',
                         fileSizeBytes,
@@ -4806,7 +4818,7 @@ function Ktl($, appInfo) {
                     }, 'warn');
                 }
 
-                if (Number.isFinite(maxAssetSizeBytes) && maxAssetSizeBytes > 0 && fileSizeBytes > maxAssetSizeBytes) {
+                if (hasKnownFileSize && Number.isFinite(maxAssetSizeBytes) && maxAssetSizeBytes > 0 && fileSizeBytes > maxAssetSizeBytes) {
                     const sizeMessage = `KTL API error: uploadAsset file size ${this._formatByteSize(fileSizeBytes)} exceeds configured max ${this._formatByteSize(maxAssetSizeBytes)}.`;
                     if (enforceAssetSize) {
                         throw new Error(sizeMessage);

--- a/KTL_AI_Instructions.md
+++ b/KTL_AI_Instructions.md
@@ -87,6 +87,13 @@ This guide captures the Knack Toolkit Library (KTL) architecture and conventions
 - **`KTL.css`**: prefix conventions, spacing variables, feature grouping.
 - **`KTL_Defaults.js`**: configuration patterns and defaults (when adding new settings).
 
+## 7. Documentation Maintenance Rules
+- Before changing an existing feature, check `LIB/KTL/Docs/` for a related doc (for example `KTL_API.md`).
+- If a related doc exists, update it in the same change so behavior and options remain accurate.
+- If no related doc exists, create one only when the feature/change is complex (multi-step behavior, non-obvious API contracts, advanced configuration, or cross-module impact).
+- Do not create docs for small/simple changes; keep those in code comments or commit messages.
+- When adding a new complex-feature doc, place it under `LIB/KTL/Docs/` and use a clear feature-based filename.
+
 ---
 
 These guidelines are intended to keep changes consistent with the existing KTL codebase and reduce risk when extending shared functionality.

--- a/KTL_AI_Instructions.md
+++ b/KTL_AI_Instructions.md
@@ -88,11 +88,11 @@ This guide captures the Knack Toolkit Library (KTL) architecture and conventions
 - **`KTL_Defaults.js`**: configuration patterns and defaults (when adding new settings).
 
 ## 7. Documentation Maintenance Rules
-- Before changing an existing feature, check `LIB/KTL/Docs/` for a related doc (for example `KTL_API.md`).
+- Before changing an existing feature, check `Docs/` for a related doc (for example `KTL_API.md`).
 - If a related doc exists, update it in the same change so behavior and options remain accurate.
 - If no related doc exists, create one only when the feature/change is complex (multi-step behavior, non-obvious API contracts, advanced configuration, or cross-module impact).
 - Do not create docs for small/simple changes; keep those in code comments or commit messages.
-- When adding a new complex-feature doc, place it under `LIB/KTL/Docs/` and use a clear feature-based filename.
+- When adding a new complex-feature doc, place it under `Docs/` and use a clear feature-based filename.
 
 ---
 


### PR DESCRIPTION
Previous behavior flattened caller rules into an and group when caller passed match/rules, which could silently convert caller or intent into and. New behavior nests caller filters as a single sub-rule under the base equality filter, preserving caller match semantics. Improve paged read resilience in getAllRecords and getAllChildRecords.

Replace Promise.all batch fetch with allSettled handling so successful pages are retained even if one page fails. Add optional failOnPageError to support strict fail-fast behavior when required. Add warning logs with page context for failed pages. Route uploadAsset through the shared request pipeline.

Remove standalone fetch path and use common request logic for retries, backoff, timeout, and 429 handling consistency. Maintain write queue integration and existing return contract. Add configurable asset-size policy in uploadAsset.

New create-level and per-call controls: warnAssetSizeBytes maxAssetSizeBytes enforceAssetSize Warn when size exceeds warning threshold. Reject early with clear error when enforcement is enabled and max size is exceeded. Add human-readable byte formatting helper for diagnostics. Simplify request error construction.

Remove dead response-like shape branch that was never hit by current call paths. Keep structured error contract with status and body. Harden updateRecords input-shape detection.

Validate all elements before entering per-record mode. Throw clear error for mixed arrays instead of failing later during execution. Documentation updates.

Expand KTL API docs with new options, defaults, behavior changes, and read-path error semantics. Add AI workflow rule to check existing docs first, update when present, and only create docs for complex features.