### PR TITLE
Simplifies API method signatures by removing refreshViews param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Knack Toolkit Library Changelog
 
+## 0.41.1    *2026-03-06*
+
+- `ktl.api` bulk write defaults and validation hardening:
+  - Change default `continueOnError` to `true` for `createRecords`, `updateRecords`, and `deleteRecords`
+  - Enforce plain-object `options` across write methods (`createRecord(s)`, `updateRecord(s)`, `deleteRecord(s)`)
+  - Improve worker scheduling for `continueOnError: false` to reduce additional tasks being claimed after first failure
+- `ktl.api` logging cleanup:
+  - Route concurrent bulk summary logs through debug-gated API logger (no unconditional console output)
+
 
 ## 0.41.0    *2026-02-21*
 

--- a/Docs/KTL_API.md
+++ b/Docs/KTL_API.md
@@ -163,10 +163,10 @@ Many methods share these options:
 - `rawResponse`: return Knack raw payload instead of records array
 - `onProgress`: callback for paged or bulk operations
 - `failOnPageError`: when true, paged parallel reads throw if any page fails (default false = keep successful pages)
+- `refreshViews` (`string | string[]`): view id(s) to refresh after write completion (supported by all write methods)
 
 Bulk write options:
 
-- `refreshViews` (`string | string[]`): view id(s) to refresh after write completion
 - `continueOnError` (default `false`)
 - `staggerMs` (default `0`)
 

--- a/Docs/KTL_API.md
+++ b/Docs/KTL_API.md
@@ -94,7 +94,7 @@ Creates one record.
 Creates many records using write queue controls.
 
 - Returns: `{ total, created, failed, records }`
-- Supports `continueOnError`, `staggerMs`, `onProgress`
+- Supports `continueOnError` (default `true`), `staggerMs`, `onProgress`
 
 ### `updateRecord(viewId, recordId, recordData, options?)`
 Updates one record.
@@ -103,10 +103,8 @@ Updates one record.
 Updates many records with queue controls.
 
 - Returns: `{ total, updated, failed }`
-- Supports two input shapes:
-  - Shared-data mode: `recordIds: string[]` + shared `recordData`
-  - Per-record mode: `recordIds: Array<{ id, data }>`
-- Mixed arrays (e.g., first item object, later items string IDs) now throw a clear validation error
+- Requires `recordIds: string[]` plus shared `recordData: Object`
+- `recordData` must be a plain object
 
 ### `uploadAsset(file, options?)`
 Uploads one file/image asset and returns uploaded asset metadata.
@@ -167,8 +165,12 @@ Many methods share these options:
 
 Bulk write options:
 
-- `continueOnError` (default `false`)
+- `continueOnError` (default `true`)
 - `staggerMs` (default `0`)
+
+Write-method validation:
+
+- All write method `options` must be a plain object when provided
 
 Asset upload options:
 

--- a/Docs/KTL_API.md
+++ b/Docs/KTL_API.md
@@ -24,10 +24,13 @@ The module exposes a shared singleton API instance plus `create(options)` for cu
 const records = await ktl.api.getRecords('view_123');
 
 // Update one record
-await ktl.api.updateRecord('view_123', '64f...', { field_1: 'Updated' }, ['view_123']);
+await ktl.api.updateRecord('view_123', '64f...', { field_1: 'Updated' }, {
+  refreshViews: ['view_123']
+});
 
 // Bulk update with progress
-const result = await ktl.api.updateRecords('view_123', recIds, { field_2: 'Yes' }, [], {
+const result = await ktl.api.updateRecords('view_123', recIds, { field_2: 'Yes' }, {
+  refreshViews: [],
   continueOnError: false,
   staggerMs: 40,
   onProgress: ({ updated, failed, total }) => {
@@ -84,19 +87,19 @@ Gets all pages of child records.
 
 ## Write methods
 
-### `createRecord(viewId, recordData, refreshViews?, options?)`
+### `createRecord(viewId, recordData, options?)`
 Creates one record.
 
-### `createRecords(viewId, recordsData, refreshViews?, options?)`
+### `createRecords(viewId, recordsData, options?)`
 Creates many records using write queue controls.
 
 - Returns: `{ total, created, failed, records }`
 - Supports `continueOnError`, `staggerMs`, `onProgress`
 
-### `updateRecord(viewId, recordId, recordData, refreshViews?, options?)`
+### `updateRecord(viewId, recordId, recordData, options?)`
 Updates one record.
 
-### `updateRecords(viewId, recordIds, recordData, refreshViews?, options?)`
+### `updateRecords(viewId, recordIds, recordData, options?)`
 Updates many records with queue controls.
 
 - Returns: `{ total, updated, failed }`
@@ -114,10 +117,10 @@ Uploads one file/image asset and returns uploaded asset metadata.
   - `maxAssetSizeBytes` (optional hard max)
   - `enforceAssetSize` (reject early when max exceeded)
 
-### `deleteRecord(viewId, recordId, refreshViews?, options?)`
+### `deleteRecord(viewId, recordId, options?)`
 Deletes one record.
 
-### `deleteRecords(viewId, recordIds, refreshViews?, options?)`
+### `deleteRecords(viewId, recordIds, options?)`
 Deletes many records with queue controls.
 
 - Returns: `{ total, deleted, failed }`
@@ -163,6 +166,7 @@ Many methods share these options:
 
 Bulk write options:
 
+- `refreshViews` (`string | string[]`): view id(s) to refresh after write completion
 - `continueOnError` (default `false`)
 - `staggerMs` (default `0`)
 

--- a/KTL.js
+++ b/KTL.js
@@ -4663,6 +4663,9 @@ function Ktl($, appInfo) {
              * @returns {Promise<Object>}
              */
             async createRecord(viewId, recordData, options = {}) {
+                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
+                    throw new Error('KTL API: The positional refreshViews argument has been removed from createRecord. Use options.refreshViews instead, e.g. createRecord(viewId, data, { refreshViews: [...] }).');
+                }
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId);
                 const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
@@ -4700,6 +4703,9 @@ function Ktl($, appInfo) {
              * @returns {Promise<{ total: number, created: number, failed: number, records: Object[] }>}
              */
             async createRecords(viewId, recordsData, options = {}) {
+                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
+                    throw new Error('KTL API: The positional refreshViews argument has been removed from createRecords. Use options.refreshViews instead, e.g. createRecords(viewId, data, { refreshViews: [...] }).');
+                }
                 const payloads = Array.isArray(recordsData) ? recordsData.filter(Boolean) : [];
                 const total = payloads.length;
                 if (!total) return { total: 0, created: 0, failed: 0, records: [] };
@@ -4938,6 +4944,9 @@ function Ktl($, appInfo) {
              * @returns {Promise<Object>}
              */
             async updateRecord(viewId, recordId, recordData, options = {}) {
+                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
+                    throw new Error('KTL API: The positional refreshViews argument has been removed from updateRecord. Use options.refreshViews instead, e.g. updateRecord(viewId, recordId, data, { refreshViews: [...] }).');
+                }
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId, recordId);
                 const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
@@ -4993,6 +5002,20 @@ function Ktl($, appInfo) {
 
                 if (hasMixedPerRecordShape) {
                     throw new Error('KTL API error: updateRecords received a mixed array. Use all IDs with shared data, or all objects with {id, data}.');
+                }
+
+                if (isPerRecord) {
+                    // Per-record shape: updateRecords(viewId, [{id, data}], options)
+                    // Guard against legacy updateRecords(viewId, records, refreshViews, options)
+                    if (recordData !== undefined && (Array.isArray(recordData) || typeof recordData === 'string')) {
+                        throw new Error('KTL API: The positional refreshViews argument has been removed from updateRecords. Use options.refreshViews instead, e.g. updateRecords(viewId, records, { refreshViews: [...] }).');
+                    }
+                } else {
+                    // Shared-data shape: updateRecords(viewId, recordIds, recordData, options)
+                    // Guard against legacy updateRecords(viewId, recordIds, recordData, refreshViews, options)
+                    if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
+                        throw new Error('KTL API: The positional refreshViews argument has been removed from updateRecords. Use options.refreshViews instead, e.g. updateRecords(viewId, recordIds, data, { refreshViews: [...] }).');
+                    }
                 }
 
                 let records, effectiveRefresh, opts;
@@ -5069,6 +5092,9 @@ function Ktl($, appInfo) {
              * @returns {Promise<Object>}
              */
             async deleteRecord(viewId, recordId, options = {}) {
+                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
+                    throw new Error('KTL API: The positional refreshViews argument has been removed from deleteRecord. Use options.refreshViews instead, e.g. deleteRecord(viewId, recordId, { refreshViews: [...] }).');
+                }
                 const opts = options || {};
                 const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
                 const url = this._formatApiUrl(viewId, recordId);
@@ -5099,6 +5125,9 @@ function Ktl($, appInfo) {
              * @returns {Promise<{ total: number, deleted: number, failed: number }>}
              */
             async deleteRecords(viewId, recordIds, options = {}) {
+                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
+                    throw new Error('KTL API: The positional refreshViews argument has been removed from deleteRecords. Use options.refreshViews instead, e.g. deleteRecords(viewId, recordIds, { refreshViews: [...] }).');
+                }
                 const ids = Array.isArray(recordIds) ? recordIds.filter(Boolean) : [];
                 const total = ids.length;
                 if (!total) return { total: 0, deleted: 0, failed: 0 };

--- a/KTL.js
+++ b/KTL.js
@@ -4663,9 +4663,7 @@ function Ktl($, appInfo) {
              * @returns {Promise<Object>}
              */
             async createRecord(viewId, recordData, options = {}) {
-                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
-                    throw new Error('KTL API: The positional refreshViews argument has been removed from createRecord. Use options.refreshViews instead, e.g. createRecord(viewId, data, { refreshViews: [...] }).');
-                }
+                this._assertWriteOptions(options, 'createRecord');
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId);
                 const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
@@ -4696,16 +4694,14 @@ function Ktl($, appInfo) {
              * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
              * @param {number} [options.staggerMs=0]
-             * @param {boolean} [options.continueOnError=false]
+             * @param {boolean} [options.continueOnError=true]
              * @param {boolean} [options.autoUploadAssets=false] - When true, File/Blob values are uploaded first and replaced by asset ids.
              * @param {string[]} [options.assetFieldIds] - Optional allow-list of field keys eligible for auto asset upload.
              * @param {Object<string, 'file'|'image'>} [options.assetTypesByField] - Optional per-field asset type override.
              * @returns {Promise<{ total: number, created: number, failed: number, records: Object[] }>}
              */
             async createRecords(viewId, recordsData, options = {}) {
-                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
-                    throw new Error('KTL API: The positional refreshViews argument has been removed from createRecords. Use options.refreshViews instead, e.g. createRecords(viewId, data, { refreshViews: [...] }).');
-                }
+                this._assertWriteOptions(options, 'createRecords');
                 const payloads = Array.isArray(recordsData) ? recordsData.filter(Boolean) : [];
                 const total = payloads.length;
                 if (!total) return { total: 0, created: 0, failed: 0, records: [] };
@@ -4944,9 +4940,7 @@ function Ktl($, appInfo) {
              * @returns {Promise<Object>}
              */
             async updateRecord(viewId, recordId, recordData, options = {}) {
-                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
-                    throw new Error('KTL API: The positional refreshViews argument has been removed from updateRecord. Use options.refreshViews instead, e.g. updateRecord(viewId, recordId, data, { refreshViews: [...] }).');
-                }
+                this._assertWriteOptions(options, 'updateRecord');
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId, recordId);
                 const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
@@ -4970,63 +4964,29 @@ function Ktl($, appInfo) {
             /**
              * Update multiple records in a view using write concurrency.
              *
-             * Accepts two calling shapes:
-             *   - Shared data:   updateRecords(viewId, recordIds, recordData, options)
-             *   - Per-record:    updateRecords(viewId, records, options)
-             *     where `records` is Array<{id: string, data: Object}>
-             *
              * @param {string} viewId
-             * @param {string[]|Array<{id:string,data:Object}>} recordIds - Array of record IDs (shared-data shape) or per-record objects.
-             * @param {Object} recordData - Shared record data (shared-data shape) or the options object (per-record shape).
+             * @param {string[]} recordIds
+             * @param {Object} recordData
              * @param {Object} [options]
              * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
              * @param {number} [options.staggerMs=0]
-             * @param {boolean} [options.continueOnError=false]
+             * @param {boolean} [options.continueOnError=true]
              * @returns {Promise<{ total: number, updated: number, failed: number }>}
              */
             async updateRecords(viewId, recordIds, recordData, options = {}) {
-                // Detect per-record shape: Array<{id, data}>
-                const isPerRecord = Array.isArray(recordIds)
-                    && recordIds.length > 0
-                    && recordIds.every(record =>
-                        record !== null
-                        && typeof record === 'object'
-                        && 'id' in record
-                        && 'data' in record
-                    );
-
-                const hasMixedPerRecordShape = Array.isArray(recordIds)
-                    && recordIds.some(record => record !== null && typeof record === 'object')
-                    && !isPerRecord;
-
-                if (hasMixedPerRecordShape) {
-                    throw new Error('KTL API error: updateRecords received a mixed array. Use all IDs with shared data, or all objects with {id, data}.');
+                this._assertWriteOptions(options, 'updateRecords');
+                if (!Array.isArray(recordIds)) {
+                    throw new Error('KTL API error: updateRecords requires recordIds to be an array.');
                 }
 
-                if (isPerRecord) {
-                    // Per-record shape: updateRecords(viewId, [{id, data}], options)
-                    // Guard against legacy updateRecords(viewId, records, refreshViews, options)
-                    if (recordData !== undefined && (Array.isArray(recordData) || typeof recordData === 'string')) {
-                        throw new Error('KTL API: The positional refreshViews argument has been removed from updateRecords. Use options.refreshViews instead, e.g. updateRecords(viewId, records, { refreshViews: [...] }).');
-                    }
-                } else {
-                    // Shared-data shape: updateRecords(viewId, recordIds, recordData, options)
-                    // Guard against legacy updateRecords(viewId, recordIds, recordData, refreshViews, options)
-                    if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
-                        throw new Error('KTL API: The positional refreshViews argument has been removed from updateRecords. Use options.refreshViews instead, e.g. updateRecords(viewId, recordIds, data, { refreshViews: [...] }).');
-                    }
+                if (!recordData || typeof recordData !== 'object' || Array.isArray(recordData)) {
+                    throw new Error('KTL API error: updateRecords requires recordData to be an object.');
                 }
 
-                let records, effectiveRefresh, opts;
-                if (isPerRecord) {
-                    // updateRecords(viewId, [{id, data}, ...], options)
-                    records = recordIds.filter(r => r && r.id);
-                    opts = (recordData && typeof recordData === 'object' && !Array.isArray(recordData)) ? recordData : {};
-                } else {
-                    records = (Array.isArray(recordIds) ? recordIds.filter(Boolean) : []).map(id => ({ id, data: recordData }));
-                    opts = options || {};
-                }
+                const records = recordIds.filter(Boolean).map(id => ({ id, data: recordData }));
+                const opts = options || {};
+                let effectiveRefresh;
                 effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
                 const batchOptions = { ...opts };
                 delete batchOptions.refreshViews;
@@ -5092,9 +5052,7 @@ function Ktl($, appInfo) {
              * @returns {Promise<Object>}
              */
             async deleteRecord(viewId, recordId, options = {}) {
-                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
-                    throw new Error('KTL API: The positional refreshViews argument has been removed from deleteRecord. Use options.refreshViews instead, e.g. deleteRecord(viewId, recordId, { refreshViews: [...] }).');
-                }
+                this._assertWriteOptions(options, 'deleteRecord');
                 const opts = options || {};
                 const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
                 const url = this._formatApiUrl(viewId, recordId);
@@ -5121,13 +5079,11 @@ function Ktl($, appInfo) {
              * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
              * @param {number} [options.staggerMs=0]
-             * @param {boolean} [options.continueOnError=false]
+             * @param {boolean} [options.continueOnError=true]
              * @returns {Promise<{ total: number, deleted: number, failed: number }>}
              */
             async deleteRecords(viewId, recordIds, options = {}) {
-                if (options !== undefined && (Array.isArray(options) || typeof options === 'string')) {
-                    throw new Error('KTL API: The positional refreshViews argument has been removed from deleteRecords. Use options.refreshViews instead, e.g. deleteRecords(viewId, recordIds, { refreshViews: [...] }).');
-                }
+                this._assertWriteOptions(options, 'deleteRecords');
                 const ids = Array.isArray(recordIds) ? recordIds.filter(Boolean) : [];
                 const total = ids.length;
                 if (!total) return { total: 0, deleted: 0, failed: 0 };
@@ -5399,18 +5355,21 @@ function Ktl($, appInfo) {
              * @private
              */
             _buildBatchContext(total, options = {}, on429 = () => { }) {
+                this._assertWriteOptions(options, 'batch operation');
                 const opts = options || {};
+                const continueOnError = opts.continueOnError !== false;
                 const staggerMs = Math.max(0, Number(opts.staggerMs) || 0);
                 const queue = this._writeQueue || {};
                 const workerCount = Math.max(1, Math.min(total, Math.floor(queue.current || this.options.writeConcurrency || 1)));
                 const requestOptions = {
                     ...opts,
+                    continueOnError,
                     _on429: () => {
                         typeof on429 === 'function' && on429();
                     }
                 };
 
-                return { opts, staggerMs, workerCount, requestOptions };
+                return { opts: { ...opts, continueOnError }, staggerMs, workerCount, requestOptions };
             }
 
             /**
@@ -5423,7 +5382,11 @@ function Ktl($, appInfo) {
              * @private
              */
             _logBatchSummary(operation, viewId, processed, total, rateLimit429Count) {
-                console.log(`[KTL API] Concurrent ${operation} summary for view ${viewId}: processed ${processed}/${total}, 429s ${rateLimit429Count}`);
+                this._log(
+                    `Concurrent ${operation} summary`,
+                    { viewId, processed, total, rateLimit429Count },
+                    'info'
+                );
             }
 
             /**
@@ -5448,7 +5411,7 @@ function Ktl($, appInfo) {
              * @param {number} config.total
              * @param {number} config.workerCount
              * @param {number} [config.staggerMs=0]
-             * @param {boolean} [config.continueOnError=false]
+             * @param {boolean} [config.continueOnError=true]
              * @param {(index:number)=>Promise<void>} config.execute
              * @returns {Promise<{firstError: Error|null}>}
              * @private
@@ -5457,7 +5420,7 @@ function Ktl($, appInfo) {
                 const total = Number.isFinite(config.total) ? config.total : 0;
                 const workerCount = Number.isFinite(config.workerCount) ? Math.max(1, Math.floor(config.workerCount)) : 1;
                 const staggerMs = Number.isFinite(config.staggerMs) ? Math.max(0, Math.floor(config.staggerMs)) : 0;
-                const continueOnError = config.continueOnError === true;
+                const continueOnError = config.continueOnError !== false;
                 const execute = typeof config.execute === 'function' ? config.execute : null;
 
                 if (!execute)
@@ -5476,15 +5439,15 @@ function Ktl($, appInfo) {
                         if (stopScheduling && !continueOnError)
                             return;
 
-                        const index = nextIndex;
-                        nextIndex += 1;
-                        if (index >= total)
-                            return;
-
                         if (staggerMs > 0)
                             await delay(staggerMs);
 
                         if (stopScheduling && !continueOnError)
+                            return;
+
+                        const index = nextIndex;
+                        nextIndex += 1;
+                        if (index >= total)
                             return;
 
                         try {
@@ -5499,6 +5462,31 @@ function Ktl($, appInfo) {
 
                 await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
                 return { firstError };
+            }
+
+            /**
+             * Check whether a value is a plain object.
+             * @param {*} value
+             * @returns {boolean}
+             * @private
+             */
+            _isPlainObject(value) {
+                if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+                const proto = Object.getPrototypeOf(value);
+                return proto === Object.prototype || proto === null;
+            }
+
+            /**
+             * Assert that method options are a plain object when provided.
+             * @param {*} options
+             * @param {string} methodName
+             * @private
+             */
+            _assertWriteOptions(options, methodName) {
+                if (options === undefined) return;
+                if (!this._isPlainObject(options)) {
+                    throw new Error(`KTL API error: ${methodName} options must be a plain object.`);
+                }
             }
 
             /**
@@ -6123,8 +6111,8 @@ function Ktl($, appInfo) {
             /**
              * Update multiple records in a view.
              * @param {string} viewId
-             * @param {string[]|Array<{id:string,data:Object}>} recordIds
-             * @param {Object} recordData - Shared record data (shared-data shape) or the options object (per-record shape).
+             * @param {string[]} recordIds
+             * @param {Object} recordData
              * @param {Object} [options]
              * @param {Array|string} [options.refreshViews]
              * @returns {Promise<{ total: number, updated: number, failed: number }>}

--- a/KTL.js
+++ b/KTL.js
@@ -4963,6 +4963,7 @@ function Ktl($, appInfo) {
              *   - Shared data:   updateRecords(viewId, recordIds, recordData, options)
              *   - Per-record:    updateRecords(viewId, records, options)
              *     where `records` is Array<{id: string, data: Object}>
+             *     (legacy 4th-arg options are merged when provided)
              *
              * @param {string} viewId
              * @param {string[]|Array<{id:string,data:Object}>} recordIds - Array of record IDs (shared-data shape) or per-record objects.
@@ -4995,9 +4996,11 @@ function Ktl($, appInfo) {
 
                 let records, effectiveRefresh, opts;
                 if (isPerRecord) {
-                    // updateRecords(viewId, [{id, data}, ...], options)
+                    // updateRecords(viewId, [{id, data}, ...], options[, legacyOptions])
                     records = recordIds.filter(r => r && r.id);
-                    opts = (recordData && typeof recordData === 'object' && !Array.isArray(recordData)) ? recordData : {};
+                    const perRecordOptions = (recordData && typeof recordData === 'object' && !Array.isArray(recordData)) ? recordData : {};
+                    const legacyOptions = (options && typeof options === 'object' && !Array.isArray(options)) ? options : {};
+                    opts = { ...perRecordOptions, ...legacyOptions };
                 } else {
                     records = (Array.isArray(recordIds) ? recordIds.filter(Boolean) : []).map(id => ({ id, data: recordData }));
                     opts = options || {};
@@ -5370,6 +5373,7 @@ function Ktl($, appInfo) {
                 const workerCount = Math.max(1, Math.min(total, Math.floor(queue.current || this.options.writeConcurrency || 1)));
                 const requestOptions = {
                     ...opts,
+                    refreshViews: undefined,
                     _on429: () => {
                         typeof on429 === 'function' && on429();
                     }

--- a/KTL.js
+++ b/KTL.js
@@ -4710,10 +4710,12 @@ function Ktl($, appInfo) {
                 let firstError = null;
                 const failedIndices = [];
                 const createdRecords = [];
-                const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, options, () => {
+                const effectiveRefresh = this._normalizeRefreshViews(options?.refreshViews);
+                const batchOptions = { ...(options || {}) };
+                delete batchOptions.refreshViews;
+                const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, batchOptions, () => {
                     rateLimit429Count += 1;
                 });
-                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
 
                 try {
                     const batchResult = await this._runBatchWorkers({
@@ -5003,6 +5005,8 @@ function Ktl($, appInfo) {
                     opts = options || {};
                 }
                 effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
+                const batchOptions = { ...opts };
+                delete batchOptions.refreshViews;
 
                 const total = records.length;
                 if (!total) return { total: 0, updated: 0, failed: 0 };
@@ -5012,7 +5016,7 @@ function Ktl($, appInfo) {
                 let rateLimit429Count = 0;
                 let firstError = null;
                 const failedRecordIds = [];
-                const { opts: batchOpts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, opts, () => {
+                const { opts: batchOpts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, batchOptions, () => {
                     rateLimit429Count += 1;
                 });
 
@@ -5104,10 +5108,12 @@ function Ktl($, appInfo) {
                 let rateLimit429Count = 0;
                 let firstError = null;
                 const failedRecordIds = [];
-                const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, options, () => {
+                const effectiveRefresh = this._normalizeRefreshViews(options?.refreshViews);
+                const batchOptions = { ...(options || {}) };
+                delete batchOptions.refreshViews;
+                const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, batchOptions, () => {
                     rateLimit429Count += 1;
                 });
-                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
 
                 try {
                     const batchResult = await this._runBatchWorkers({
@@ -5368,10 +5374,8 @@ function Ktl($, appInfo) {
                 const staggerMs = Math.max(0, Number(opts.staggerMs) || 0);
                 const queue = this._writeQueue || {};
                 const workerCount = Math.max(1, Math.min(total, Math.floor(queue.current || this.options.writeConcurrency || 1)));
-                const requestOpts = { ...opts };
-                delete requestOpts.refreshViews;
                 const requestOptions = {
-                    ...requestOpts,
+                    ...opts,
                     _on429: () => {
                         typeof on429 === 'function' && on429();
                     }

--- a/KTL.js
+++ b/KTL.js
@@ -5368,9 +5368,10 @@ function Ktl($, appInfo) {
                 const staggerMs = Math.max(0, Number(opts.staggerMs) || 0);
                 const queue = this._writeQueue || {};
                 const workerCount = Math.max(1, Math.min(total, Math.floor(queue.current || this.options.writeConcurrency || 1)));
+                const requestOpts = { ...opts };
+                delete requestOpts.refreshViews;
                 const requestOptions = {
-                    ...opts,
-                    refreshViews: undefined,
+                    ...requestOpts,
                     _on429: () => {
                         typeof on429 === 'function' && on429();
                     }

--- a/KTL.js
+++ b/KTL.js
@@ -4968,7 +4968,7 @@ function Ktl($, appInfo) {
              *
              * @param {string} viewId
              * @param {string[]|Array<{id:string,data:Object}>} recordIds - Array of record IDs (shared-data shape) or per-record objects.
-             * @param {Object|Array|string} recordData - Shared record data (shared-data shape) or the options param (per-record shape).
+             * @param {Object} recordData - Shared record data (shared-data shape) or the options object (per-record shape).
              * @param {Object} [options]
              * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
@@ -6095,7 +6095,7 @@ function Ktl($, appInfo) {
              * Update multiple records in a view.
              * @param {string} viewId
              * @param {string[]|Array<{id:string,data:Object}>} recordIds
-             * @param {Object|Array|string} recordData
+             * @param {Object} recordData - Shared record data (shared-data shape) or the options object (per-record shape).
              * @param {Object} [options]
              * @param {Array|string} [options.refreshViews]
              * @returns {Promise<{ total: number, updated: number, failed: number }>}

--- a/KTL.js
+++ b/KTL.js
@@ -4655,20 +4655,17 @@ function Ktl($, appInfo) {
              * Create a record in a view.
              * @param {string} viewId
              * @param {Object} recordData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
-             * @param {Array|string} [options.refreshViews] - Alternative to the positional refreshViews param.
+             * @param {Array|string} [options.refreshViews]
              * @param {boolean} [options.autoUploadAssets=false] - When true, File/Blob values are uploaded first and replaced by asset ids.
              * @param {string[]} [options.assetFieldIds] - Optional allow-list of field keys eligible for auto asset upload.
              * @param {Object<string, 'file'|'image'>} [options.assetTypesByField] - Optional per-field asset type override.
              * @returns {Promise<Object>}
              */
-            async createRecord(viewId, recordData, refreshViews, options = {}) {
+            async createRecord(viewId, recordData, options = {}) {
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId);
-                const effectiveRefresh = this._normalizeRefreshViews(
-                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
-                );
+                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
 
                 const preparedRecordData = await this._prepareRecordData(recordData, opts);
 
@@ -4692,9 +4689,8 @@ function Ktl($, appInfo) {
              * Create multiple records in a view using write concurrency.
              * @param {string} viewId
              * @param {Object[]} recordsData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
-             * @param {Array|string} [options.refreshViews] - Alternative to the positional refreshViews param.
+             * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
              * @param {number} [options.staggerMs=0]
              * @param {boolean} [options.continueOnError=false]
@@ -4703,7 +4699,7 @@ function Ktl($, appInfo) {
              * @param {Object<string, 'file'|'image'>} [options.assetTypesByField] - Optional per-field asset type override.
              * @returns {Promise<{ total: number, created: number, failed: number, records: Object[] }>}
              */
-            async createRecords(viewId, recordsData, refreshViews, options = {}) {
+            async createRecords(viewId, recordsData, options = {}) {
                 const payloads = Array.isArray(recordsData) ? recordsData.filter(Boolean) : [];
                 const total = payloads.length;
                 if (!total) return { total: 0, created: 0, failed: 0, records: [] };
@@ -4717,9 +4713,7 @@ function Ktl($, appInfo) {
                 const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, options, () => {
                     rateLimit429Count += 1;
                 });
-                const effectiveRefresh = this._normalizeRefreshViews(
-                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
-                );
+                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
 
                 try {
                     const batchResult = await this._runBatchWorkers({
@@ -4729,7 +4723,7 @@ function Ktl($, appInfo) {
                         continueOnError: opts.continueOnError,
                         execute: async (index) => {
                             try {
-                                const record = await this.createRecord(viewId, payloads[index], [], requestOptions);
+                                const record = await this.createRecord(viewId, payloads[index], requestOptions);
                                 created += 1;
                                 createdRecords[index] = record;
                                 if (typeof opts.onProgress === 'function')
@@ -4934,20 +4928,17 @@ function Ktl($, appInfo) {
              * @param {string} viewId
              * @param {string} recordId
              * @param {Object} recordData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
-             * @param {Array|string} [options.refreshViews] - Alternative to the positional refreshViews param.
+             * @param {Array|string} [options.refreshViews]
              * @param {boolean} [options.autoUploadAssets=false] - When true, File/Blob values are uploaded first and replaced by asset ids.
              * @param {string[]} [options.assetFieldIds] - Optional allow-list of field keys eligible for auto asset upload.
              * @param {Object<string, 'file'|'image'>} [options.assetTypesByField] - Optional per-field asset type override.
              * @returns {Promise<Object>}
              */
-            async updateRecord(viewId, recordId, recordData, refreshViews, options = {}) {
+            async updateRecord(viewId, recordId, recordData, options = {}) {
                 const opts = options || {};
                 const url = this._formatApiUrl(viewId, recordId);
-                const effectiveRefresh = this._normalizeRefreshViews(
-                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
-                );
+                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
                 const preparedRecordData = await this._prepareRecordData(recordData, opts);
                 return await this._enqueueWrite(async () => {
                     const result = await this._request(
@@ -4969,22 +4960,21 @@ function Ktl($, appInfo) {
              * Update multiple records in a view using write concurrency.
              *
              * Accepts two calling shapes:
-             *   - Shared data:   updateRecords(viewId, recordIds, recordData, refreshViews, options)
-             *   - Per-record:    updateRecords(viewId, records, refreshViews, options)
+             *   - Shared data:   updateRecords(viewId, recordIds, recordData, options)
+             *   - Per-record:    updateRecords(viewId, records, options)
              *     where `records` is Array<{id: string, data: Object}>
              *
              * @param {string} viewId
              * @param {string[]|Array<{id:string,data:Object}>} recordIds - Array of record IDs (shared-data shape) or per-record objects.
-             * @param {Object|Array|string} recordData - Shared record data (shared-data shape) or the refreshViews param (per-record shape).
-             * @param {Array|string} [refreshViews]
+             * @param {Object|Array|string} recordData - Shared record data (shared-data shape) or the options param (per-record shape).
              * @param {Object} [options]
-             * @param {Array|string} [options.refreshViews] - Alternative to the positional refreshViews param.
+             * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
              * @param {number} [options.staggerMs=0]
              * @param {boolean} [options.continueOnError=false]
              * @returns {Promise<{ total: number, updated: number, failed: number }>}
              */
-            async updateRecords(viewId, recordIds, recordData, refreshViews, options = {}) {
+            async updateRecords(viewId, recordIds, recordData, options = {}) {
                 // Detect per-record shape: Array<{id, data}>
                 const isPerRecord = Array.isArray(recordIds)
                     && recordIds.length > 0
@@ -5005,18 +4995,14 @@ function Ktl($, appInfo) {
 
                 let records, effectiveRefresh, opts;
                 if (isPerRecord) {
-                    // updateRecords(viewId, [{id, data}, ...], refreshViews, options)
+                    // updateRecords(viewId, [{id, data}, ...], options)
                     records = recordIds.filter(r => r && r.id);
-                    opts = (refreshViews && typeof refreshViews === 'object' && !Array.isArray(refreshViews)) ? refreshViews : {};
-                    effectiveRefresh = opts?.refreshViews !== undefined
-                        ? opts.refreshViews
-                        : recordData; // positional shift
+                    opts = (recordData && typeof recordData === 'object' && !Array.isArray(recordData)) ? recordData : {};
                 } else {
                     records = (Array.isArray(recordIds) ? recordIds.filter(Boolean) : []).map(id => ({ id, data: recordData }));
-                    effectiveRefresh = options?.refreshViews !== undefined ? options.refreshViews : refreshViews;
                     opts = options || {};
                 }
-                effectiveRefresh = this._normalizeRefreshViews(effectiveRefresh);
+                effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
 
                 const total = records.length;
                 if (!total) return { total: 0, updated: 0, failed: 0 };
@@ -5039,7 +5025,7 @@ function Ktl($, appInfo) {
                         execute: async (index) => {
                             const { id: recordId, data } = records[index];
                             try {
-                                await this.updateRecord(viewId, recordId, data, [], requestOptions);
+                                await this.updateRecord(viewId, recordId, data, requestOptions);
                                 updated += 1;
                                 if (typeof batchOpts.onProgress === 'function')
                                     batchOpts.onProgress({ updated, failed, total, recordId });
@@ -5074,16 +5060,13 @@ function Ktl($, appInfo) {
              * Delete a record in a view.
              * @param {string} viewId
              * @param {string} recordId
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
-             * @param {Array|string} [options.refreshViews] - Alternative to the positional refreshViews param.
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<Object>}
              */
-            async deleteRecord(viewId, recordId, refreshViews, options = {}) {
+            async deleteRecord(viewId, recordId, options = {}) {
                 const opts = options || {};
-                const effectiveRefresh = this._normalizeRefreshViews(
-                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
-                );
+                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
                 const url = this._formatApiUrl(viewId, recordId);
                 return await this._enqueueWrite(async () => {
                     const result = await this._request(
@@ -5104,15 +5087,14 @@ function Ktl($, appInfo) {
              * Delete multiple records in a view using write concurrency.
              * @param {string} viewId
              * @param {string[]} recordIds
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
-             * @param {Array|string} [options.refreshViews] - Alternative to the positional refreshViews param.
+             * @param {Array|string} [options.refreshViews]
              * @param {Function} [options.onProgress]
              * @param {number} [options.staggerMs=0]
              * @param {boolean} [options.continueOnError=false]
              * @returns {Promise<{ total: number, deleted: number, failed: number }>}
              */
-            async deleteRecords(viewId, recordIds, refreshViews, options = {}) {
+            async deleteRecords(viewId, recordIds, options = {}) {
                 const ids = Array.isArray(recordIds) ? recordIds.filter(Boolean) : [];
                 const total = ids.length;
                 if (!total) return { total: 0, deleted: 0, failed: 0 };
@@ -5125,9 +5107,7 @@ function Ktl($, appInfo) {
                 const { opts, staggerMs, workerCount, requestOptions } = this._buildBatchContext(total, options, () => {
                     rateLimit429Count += 1;
                 });
-                const effectiveRefresh = this._normalizeRefreshViews(
-                    opts.refreshViews !== undefined ? opts.refreshViews : refreshViews
-                );
+                const effectiveRefresh = this._normalizeRefreshViews(opts.refreshViews);
 
                 try {
                     const batchResult = await this._runBatchWorkers({
@@ -5138,7 +5118,7 @@ function Ktl($, appInfo) {
                         execute: async (index) => {
                             const recordId = ids[index];
                             try {
-                                await this.deleteRecord(viewId, recordId, [], requestOptions);
+                                await this.deleteRecord(viewId, recordId, requestOptions);
                                 deleted += 1;
                                 if (typeof opts.onProgress === 'function')
                                     opts.onProgress({ deleted, failed, total, recordId });
@@ -6062,8 +6042,8 @@ function Ktl($, appInfo) {
              * Create a record in a view.
              * @param {string} viewId
              * @param {Object} recordData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<Object>}
              */
             createRecord: function (...args) {
@@ -6074,8 +6054,8 @@ function Ktl($, appInfo) {
              * Create multiple records in a view.
              * @param {string} viewId
              * @param {Object[]} recordsData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<{ total: number, created: number, failed: number, records: Object[] }>}
              */
             createRecords: function (...args) {
@@ -6097,8 +6077,8 @@ function Ktl($, appInfo) {
              * @param {string} viewId
              * @param {string} recordId
              * @param {Object} recordData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<Object>}
              */
             updateRecord: function (...args) {
@@ -6110,8 +6090,8 @@ function Ktl($, appInfo) {
              * @param {string} viewId
              * @param {string[]|Array<{id:string,data:Object}>} recordIds
              * @param {Object|Array|string} recordData
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<{ total: number, updated: number, failed: number }>}
              */
             updateRecords: function (...args) {
@@ -6122,8 +6102,8 @@ function Ktl($, appInfo) {
              * Delete a record in a view.
              * @param {string} viewId
              * @param {string} recordId
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<Object>}
              */
             deleteRecord: function (...args) {
@@ -6134,8 +6114,8 @@ function Ktl($, appInfo) {
              * Delete multiple records in a view.
              * @param {string} viewId
              * @param {string[]} recordIds
-             * @param {Array|string} [refreshViews]
              * @param {Object} [options]
+             * @param {Array|string} [options.refreshViews]
              * @returns {Promise<{ total: number, deleted: number, failed: number }>}
              */
             deleteRecords: function (...args) {
@@ -15146,7 +15126,7 @@ function Ktl($, appInfo) {
 
                 const updatePromises = recordsToUpdate.map(async ({ recId, apiData }) => {
                     try {
-                        await ktl.api.updateRecord(viewId, recId, apiData, []);
+                        await ktl.api.updateRecord(viewId, recId, apiData);
                         updatedCount++;
                         ktl.core.setInfoPopupText(`Updated ${updatedCount} of ${recordsToUpdate.length} records...`);
                         return { recId, success: true };
@@ -23902,7 +23882,7 @@ function Ktl($, appInfo) {
                             showProgress(0);
                             (async () => {
                                 try {
-                                    const result = await ktl.api.updateRecords(bulkOpsViewId, recordIds, apiData, [], {
+                                    const result = await ktl.api.updateRecords(bulkOpsViewId, recordIds, apiData, {
                                         onProgress: ({ updated }) => showProgress(updated),
                                         continueOnError: false,
                                         staggerMs: 40
@@ -32061,7 +32041,7 @@ function Ktl($, appInfo) {
                     };
 
                     showProgress(0);
-                    ktl.api.updateRecords(bulkOpsViewId, recordIds, apiData, [], {
+                    ktl.api.updateRecords(bulkOpsViewId, recordIds, apiData, {
                         autoUploadAssets: true,
                         onProgress: ({ updated }) => showProgress(updated),
                         continueOnError: false,
@@ -32097,7 +32077,7 @@ function Ktl($, appInfo) {
 
                     const recordsToCreate = Array.from({ length: numToProcess }, () => ({ ...apiData }));
 
-                    ktl.api.createRecords(bulkOpsViewId, recordsToCreate, [], {
+                    ktl.api.createRecords(bulkOpsViewId, recordsToCreate, {
                         autoUploadAssets: true,
                         onProgress: ({ created, failed }) => {
                             countDone = created + failed;
@@ -32242,7 +32222,7 @@ function Ktl($, appInfo) {
                     }
 
                     showProgress(0);
-                    ktl.api.deleteRecords(view.key, deleteArray, [], {
+                    ktl.api.deleteRecords(view.key, deleteArray, {
                         onProgress: ({ deleted }) => showProgress(deleted),
                         continueOnError: false,
                         staggerMs: 40

--- a/KTL.js
+++ b/KTL.js
@@ -4963,7 +4963,6 @@ function Ktl($, appInfo) {
              *   - Shared data:   updateRecords(viewId, recordIds, recordData, options)
              *   - Per-record:    updateRecords(viewId, records, options)
              *     where `records` is Array<{id: string, data: Object}>
-             *     (legacy 4th-arg options are merged when provided)
              *
              * @param {string} viewId
              * @param {string[]|Array<{id:string,data:Object}>} recordIds - Array of record IDs (shared-data shape) or per-record objects.
@@ -4996,11 +4995,9 @@ function Ktl($, appInfo) {
 
                 let records, effectiveRefresh, opts;
                 if (isPerRecord) {
-                    // updateRecords(viewId, [{id, data}, ...], options[, legacyOptions])
+                    // updateRecords(viewId, [{id, data}, ...], options)
                     records = recordIds.filter(r => r && r.id);
-                    const perRecordOptions = (recordData && typeof recordData === 'object' && !Array.isArray(recordData)) ? recordData : {};
-                    const legacyOptions = (options && typeof options === 'object' && !Array.isArray(options)) ? options : {};
-                    opts = { ...perRecordOptions, ...legacyOptions };
+                    opts = (recordData && typeof recordData === 'object' && !Array.isArray(recordData)) ? recordData : {};
                 } else {
                     records = (Array.isArray(recordIds) ? recordIds.filter(Boolean) : []).map(id => ({ id, data: recordData }));
                     opts = options || {};


### PR DESCRIPTION
Unifies refresh view handling by removing the separate refreshViews argument from record CRUD APIs. Only the options.refreshViews property is now used, reducing ambiguity and streamlining method usage.

Prepares the codebase for future API consistency and easier maintenance.