### PR TITLE
1. Fix Chosen connection form tracking interference

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -8318,9 +8318,13 @@ function Ktl($, appInfo) {
 
         const debouncedFormContentHasChanged = debounce(formContentHasChanged, 500);
         $(document).on('input', function (event) {
+            const targetKnInput = $(event.target).closest('.kn-input');
+            const isChosenConnectionField = targetKnInput.hasClass('kn-input-connection') && targetKnInput.find('.chzn-select').length > 0;
+
             if (!event
                 || !event.target.type
                 || event.target.className.includes('knack-date')
+                || isChosenConnectionField
                 || $(event.target).closest('.chzn-container').length)
                 return;
 
@@ -8379,6 +8383,11 @@ function Ktl($, appInfo) {
 
             const knInput = element.closest('.kn-input');
             if (!knInput) return;
+
+            if (knInput.classList.contains('kn-input-connection')
+                && knInput.querySelector('.chzn-select')
+                && !(element instanceof HTMLSelectElement))
+                return;
 
             const fieldId = knInput.getAttribute('data-input-id');
             if (!fieldId) return;

--- a/KTL.js
+++ b/KTL.js
@@ -8318,15 +8318,16 @@ function Ktl($, appInfo) {
 
         const debouncedFormContentHasChanged = debounce(formContentHasChanged, 500);
         $(document).on('input', function (event) {
-            const targetKnInput = $(event.target).closest('.kn-input');
-            const isChosenConnectionField = targetKnInput.hasClass('kn-input-connection') && targetKnInput.find('.chzn-select').length > 0;
-
             if (!event
+                || !event.target
                 || !event.target.type
                 || event.target.className.includes('knack-date')
-                || isChosenConnectionField
                 || $(event.target).closest('.chzn-container').length)
                 return;
+
+            const targetKnInput = $(event.target).closest('.kn-input');
+            const isChosenConnectionField = targetKnInput.hasClass('kn-input-connection') && targetKnInput.find('.chzn-select').length > 0;
+            if (isChosenConnectionField) return;
 
             if ((event.type === 'focusout' && event.relatedTarget) || event.type === 'input')
                 debouncedFormContentHasChanged(event.target);


### PR DESCRIPTION
## Summary
- skip KTL's generic form-content tracking for Chosen-backed connection fields
- keep the existing dedicated .chzn-select dropdown change path for persistent-form updates
- add a backstop guard inside formContentHasChanged for non-select elements from Chosen connection fields

## Testing
- targeted diff review
- local diagnostics check on touched code path