### PR TITLE
Fix connection form submit state updates

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -21059,6 +21059,14 @@ function Ktl($, appInfo) {
                 if (!viewId || !validationKey || !ktl.core.getCfg().enabled.formPreValidation) return;
 
                 var submit = document.querySelector('#' + viewId + ' .is-primary');
+                if (!submit) {
+                    const connectionSubmit = Array.from(document.querySelectorAll('.kn-submit')).find((submitElement) => {
+                        return submitElement.querySelector(`input[value="${viewId}"]`);
+                    });
+
+                    submit = connectionSubmit ? connectionSubmit.querySelector('.is-primary') : null;
+                }
+
                 if (!submit) return;
 
                 if (submit.validity) {

--- a/KTL.js
+++ b/KTL.js
@@ -8318,9 +8318,13 @@ function Ktl($, appInfo) {
 
         const debouncedFormContentHasChanged = debounce(formContentHasChanged, 500);
         $(document).on('input', function (event) {
+            const targetKnInput = $(event.target).closest('.kn-input');
+            const isChosenConnectionField = targetKnInput.hasClass('kn-input-connection') && targetKnInput.find('.chzn-select').length > 0;
+
             if (!event
                 || !event.target.type
                 || event.target.className.includes('knack-date')
+                || isChosenConnectionField
                 || $(event.target).closest('.chzn-container').length)
                 return;
 
@@ -8379,6 +8383,11 @@ function Ktl($, appInfo) {
 
             const knInput = element.closest('.kn-input');
             if (!knInput) return;
+
+            if (knInput.classList.contains('kn-input-connection')
+                && knInput.querySelector('.chzn-select')
+                && !(element instanceof HTMLSelectElement))
+                return;
 
             const fieldId = knInput.getAttribute('data-input-id');
             if (!fieldId) return;

--- a/KTL.js
+++ b/KTL.js
@@ -8317,7 +8317,7 @@ function Ktl($, appInfo) {
         });
 
         const debouncedFormContentHasChanged = debounce(formContentHasChanged, 500);
-        $(document).on('input', function (event) {
+        $(document).on('input focusout', function (event) {
             if (!event
                 || !event.target
                 || !event.target.type

--- a/KTL.js
+++ b/KTL.js
@@ -21060,10 +21060,8 @@ function Ktl($, appInfo) {
 
                 var submit = document.querySelector('#' + viewId + ' .is-primary');
                 if (!submit) {
-                    const connectionSubmit = Array.from(document.querySelectorAll('.kn-submit')).find((submitElement) => {
-                        return submitElement.querySelector(`input[value="${viewId}"]`);
-                    });
-
+                    const connectionSubmitInput = document.querySelector(`#connection-form-view input[value="${viewId}"]`);
+                    const connectionSubmit = connectionSubmitInput ? connectionSubmitInput.closest('.kn-submit') : null;
                     submit = connectionSubmit ? connectionSubmit.querySelector('.is-primary') : null;
                 }
 

--- a/KTL.js
+++ b/KTL.js
@@ -8318,15 +8318,16 @@ function Ktl($, appInfo) {
 
         const debouncedFormContentHasChanged = debounce(formContentHasChanged, 500);
         $(document).on('input', function (event) {
-            const targetKnInput = $(event.target).closest('.kn-input');
-            const isChosenConnectionField = targetKnInput.hasClass('kn-input-connection') && targetKnInput.find('.chzn-select').length > 0;
-
             if (!event
+                || !event.target
                 || !event.target.type
                 || event.target.className.includes('knack-date')
-                || isChosenConnectionField
                 || $(event.target).closest('.chzn-container').length)
                 return;
+
+            const targetKnInput = $(event.target).closest('.kn-input');
+            const isChosenConnectionField = targetKnInput.hasClass('kn-input-connection') && targetKnInput.find('.chzn-select').length > 0;
+            if (isChosenConnectionField) return;
 
             if ((event.type === 'focusout' && event.relatedTarget) || event.type === 'input')
                 debouncedFormContentHasChanged(event.target);

--- a/KTL.js
+++ b/KTL.js
@@ -21060,7 +21060,9 @@ function Ktl($, appInfo) {
 
                 var submit = document.querySelector('#' + viewId + ' .is-primary');
                 if (!submit) {
-                    const connectionSubmitInput = document.querySelector(`#connection-form-view input[value="${viewId}"]`);
+                    const connectionSubmitInput =
+                        document.querySelector(`#connection-form-view input[value="${viewId}"]`) ||
+                        document.querySelector(`.kn-submit input[value="${viewId}"]`);
                     const connectionSubmit = connectionSubmitInput ? connectionSubmitInput.closest('.kn-submit') : null;
                     submit = connectionSubmit ? connectionSubmit.querySelector('.is-primary') : null;
                 }


### PR DESCRIPTION
**Changes:**
- Guarded the global `input` handler and excluded Chosen-based connection fields from generic persistent-form text tracking.
- Added an additional Chosen-connection guard in `formContentHasChanged` to avoid processing non-`select` elements inside Chosen widgets.
- Enhanced `updateSubmitButtonState` to locate the primary submit button for connection-form layouts by falling back to `.kn-submit` discovery when `#viewId .is-primary` is missing.


## Testing
- manual review of the updated submit button lookup logic
- validated related GAP fallback separately while waiting for this KTL change to deploy
