### PR TITLE
Stick header on view open using _sth height param

### DIFF
--- a/KTL.js
+++ b/KTL.js
@@ -18573,6 +18573,13 @@ function Ktl($, appInfo) {
 
         const viewStates = {};
 
+        /**
+         * Adds hide/show controls to a view and restores dependent view features when it opens.
+         *
+         * @param {object} view Knack view being rendered.
+         * @param {object} keywords Parsed keywords for the view.
+         * @returns {void}
+         */
         function hideShowView({ key: viewId }, keywords) {
             const kw = '_hsv';
             if (!viewId || !keywords || !keywords[kw]) return;
@@ -18705,7 +18712,9 @@ function Ktl($, appInfo) {
                     hiddenSection.slideDown(delay, () => {
                         const viewHasSTH = ktl.core.checkIfViewHasKeyword(viewId, '_sth');
                         if (viewHasSTH) {
-                            ktl.views.stickTableHeader(viewId);
+                            const stickyHeaderParams = keywords._sth?.[0]?.params?.[0] || [];
+                            const viewHeight = stickyHeaderParams[1] || 800;
+                            ktl.views.stickTableHeader(viewId, viewHeight);
                         }
 
                         const signatureElements = viewElement.find('.kn-input-signature');

--- a/KTL.js
+++ b/KTL.js
@@ -18710,11 +18710,14 @@ function Ktl($, appInfo) {
                     }
                 } else {
                     hiddenSection.slideDown(delay, () => {
-                        const viewHasSTH = ktl.core.checkIfViewHasKeyword(viewId, '_sth');
-                        if (viewHasSTH) {
+                        if (keywords._sth) {
                             const stickyHeaderParams = keywords._sth?.[0]?.params?.[0] || [];
+                            const numOfRecords = stickyHeaderParams[0] || 10;
                             const viewHeight = stickyHeaderParams[1] || 800;
-                            ktl.views.stickTableHeader(viewId, viewHeight);
+                            const rowCount = Knack.views[viewId]?.model?.data?.length || 0;
+
+                            if (rowCount >= numOfRecords)
+                                ktl.views.stickTableHeader(viewId, viewHeight);
                         }
 
                         const signatureElements = viewElement.find('.kn-input-signature');


### PR DESCRIPTION
When a view with hide/show (_hsv) opens, read the height parameter from its _sth keyword and pass it to ktl.views.stickTableHeader so the sticky header uses the configured height. Add JSDoc for hideShowView to document the hide/show behavior and restoration of dependent features.